### PR TITLE
Possible patch for type mismatch for read/write-ttl

### DIFF
--- a/libsyndicate-ug/consistency.cpp
+++ b/libsyndicate-ug/consistency.cpp
@@ -17,10 +17,10 @@
 #include "consistency.h"
 #include "read.h"
 
-// ms path entry context 
+// ms path entry context
 struct UG_path_ent_ctx {
-   
-   char* fs_path;               // path to this entry 
+
+   char* fs_path;               // path to this entry
    struct fskit_entry* fent;    // entry
 };
 
@@ -40,12 +40,12 @@ static int UG_deferred_remove_cb( struct md_wreq* wreq, void* cls ) {
    struct UG_deferred_remove_ctx* ctx = (struct UG_deferred_remove_ctx*)cls;
    struct fskit_detach_ctx* dctx = NULL;
    int rc = 0;
-   
+
    SG_debug("DEFERRED: remove '%s'\n", ctx->fs_path );
-   
-   // remove the children 
+
+   // remove the children
    if( ctx->children != NULL ) {
-       
+
       dctx = fskit_detach_ctx_new();
       if( dctx == NULL ) {
          return -ENOMEM;
@@ -58,7 +58,7 @@ static int UG_deferred_remove_cb( struct md_wreq* wreq, void* cls ) {
 
       // proceed to detach
       while( true ) {
-         
+
          rc = fskit_detach_all_ex( ctx->core, ctx->fs_path, &ctx->children, dctx );
          if( rc == 0 ) {
              break;
@@ -70,7 +70,7 @@ static int UG_deferred_remove_cb( struct md_wreq* wreq, void* cls ) {
              break;
          }
       }
-      
+
       fskit_detach_ctx_free( dctx );
       SG_safe_free( dctx );
    }
@@ -78,7 +78,7 @@ static int UG_deferred_remove_cb( struct md_wreq* wreq, void* cls ) {
    SG_safe_free( ctx->fs_path );
    fskit_entry_set_free( ctx->children );
    SG_safe_free( ctx );
-   
+
    return 0;
 }
 
@@ -100,48 +100,48 @@ int UG_deferred_remove( struct UG_state* state, char const* child_path, struct f
    if( ctx == NULL ) {
        return -ENOMEM;
    }
-   
+
    work = SG_CALLOC( struct md_wreq, 1 );
    if( work == NULL ) {
-       
+
        SG_safe_free( ctx );
        return -ENOMEM;
    }
-   
-   // set up the deferred unlink request 
+
+   // set up the deferred unlink request
    ctx->core = core;
    ctx->fs_path = strdup( child_path );
-   
+
    if( ctx->fs_path == NULL ) {
-       
+
        SG_safe_free( work );
        SG_safe_free( ctx );
        return -ENOMEM;
    }
-   
+
    // garbage-collect this child
    rc = fskit_entry_tag_garbage( child, &children );
    if( rc != 0 ) {
-       
+
        SG_safe_free( ctx );
        SG_safe_free( work );
-       
+
        SG_error("fskit_entry_garbage_collect('%s') rc = %d\n", child_path, rc );
        return rc;
    }
-   
+
    ctx->children = children;
-   
-   // deferred removal 
+
+   // deferred removal
    md_wreq_init( work, UG_deferred_remove_cb, ctx, 0 );
    md_wq_add( UG_state_wq( state ), work );
-   
+
    return 0;
 }
 
 
-// go fetch the latest version of an inode directly from the MS 
-// return 0 on success, and populate *ent 
+// go fetch the latest version of an inode directly from the MS
+// return 0 on success, and populate *ent
 // return -ENOMEM on OOM
 // return -EACCES on permission error from the MS
 // return -ENOENT if the entry doesn't exist on the MS
@@ -176,18 +176,18 @@ UG_consistency_inode_download_out:
 
 
 // download a manifest, synchronously.  Try from the cache, and then from each gateway in gateway_ids, in order.
-// return 0 on success, and populate *manifest 
-// return -ENOMEM on OOM 
+// return 0 on success, and populate *manifest
+// return -ENOMEM on OOM
 // return -EINVAL if reqdat doesn't refer to a manifest
 // return -ENODATA if a manifest could not be fetched (i.e. no gateways online, all manifests obtained were invalid, etc.)
 // NOTE: does *not* check if the manifest came from a different gateway than the one contacted
 int UG_consistency_manifest_download( struct SG_gateway* gateway, struct SG_request_data* reqdat, uint64_t coordinator_id, uint64_t* gateway_ids, size_t num_gateway_ids, struct SG_manifest* manifest ) {
-   
+
    int rc = 0;
    SG_messages::Manifest mmsg;
    struct SG_chunk serialized_manifest;
    struct SG_chunk manifest_chunk;
-   
+
    if( !SG_request_is_manifest( reqdat ) ) {
       return -EINVAL;
    }
@@ -197,7 +197,7 @@ int UG_consistency_manifest_download( struct SG_gateway* gateway, struct SG_requ
    if( rc == 0 ) {
 
       // cache hit.
-      // try to verify 
+      // try to verify
       rc = SG_client_parse_manifest( gateway, reqdat, coordinator_id, &serialized_manifest, manifest );
       SG_chunk_free( &serialized_manifest );
       if( rc == 0 ) {
@@ -215,58 +215,58 @@ int UG_consistency_manifest_download( struct SG_gateway* gateway, struct SG_requ
    memset( &manifest_chunk, 0, sizeof(struct SG_chunk));
 
    for( size_t i = 0; i < num_gateway_ids; i++ ) {
-     
-      SG_debug("GET manifest %" PRIX64 ".%" PRId64 "/manifest.%ld.%ld from %" PRIu64 "\n", 
+
+      SG_debug("GET manifest %" PRIX64 ".%" PRId64 "/manifest.%ld.%ld from %" PRIu64 "\n",
             reqdat->file_id, reqdat->file_version, reqdat->manifest_timestamp.tv_sec, reqdat->manifest_timestamp.tv_nsec, gateway_ids[i] );
 
       rc = SG_client_get_manifest( gateway, reqdat, coordinator_id, gateway_ids[i], manifest );
       if( rc != 0 ) {
-         
-         // not from this one 
-         SG_warn("SG_client_get_manifest(%" PRIX64 ".%" PRId64 "/manifest.%ld.%ld) from %" PRIu64 " by %" PRIu64" rc = %d\n", 
+
+         // not from this one
+         SG_warn("SG_client_get_manifest(%" PRIX64 ".%" PRId64 "/manifest.%ld.%ld) from %" PRIu64 " by %" PRIu64" rc = %d\n",
                   reqdat->file_id, reqdat->file_version, reqdat->manifest_timestamp.tv_sec, reqdat->manifest_timestamp.tv_nsec, gateway_ids[i], coordinator_id, rc );
-         
+
          rc = -ENODATA;
          continue;
       }
       else {
          break;
-      } 
+      }
    }
-   
+
    return rc;
 }
 
 
 // Verify that a manifest is fresh.  Download and merge the latest manifest data for the referred inode if not.
 // local dirty blocks that were overwritten will be dropped and evicted on merge.
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 // return -ENODATA if we could not fetch a manifest, but needed to
 // NOTE: entry at the end of fs_path should *NOT* be locked
 // NOTE: the caller should refresh the inode first, since the manifest timestamp may have changed on the MS
 int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const* fs_path ) {
-   
+
    int rc = 0;
    struct SG_manifest new_manifest;
    struct SG_request_data reqdat;
-   
+
    uint64_t* gateway_ids_buf = NULL;
    size_t num_gateway_ids = 0;
-   
+
    int64_t manifest_mtime_sec = 0;
    int32_t manifest_mtime_nsec = 0;
-   
+
    struct fskit_entry* fent = NULL;
    struct UG_inode* inode = NULL;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    struct timespec now;
-   int64_t max_read_freshness = 0;
+   int32_t max_read_freshness = 0;
    struct timespec manifest_refresh_mtime;
-   
+
    uint64_t file_id = 0;
    int64_t file_version = 0;
    uint64_t coordinator_id = 0;
@@ -274,73 +274,73 @@ int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const
 
    memset( &now, 0, sizeof(struct timespec) );
    memset( &manifest_refresh_mtime, 0, sizeof(struct timespec) );
-   
+
    // keep around...
    fent = fskit_entry_ref( fs, fs_path, &rc );
    if( rc != 0 ) {
-      
+
       SG_error("BUG: fskit_entry_ref(%s) rc = %d\n", fs_path, rc );
       exit(1);
       return rc;
    }
-   
+
    fskit_entry_wlock( fent );
-   
+
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    manifest_refresh_mtime = UG_inode_manifest_refresh_time( inode );
    file_id = UG_inode_file_id( inode );
    file_version = UG_inode_file_version( inode );
    coordinator_id = UG_inode_coordinator_id( inode );
    max_read_freshness = UG_inode_max_read_freshness( inode );
-  
-   // TODO: test this-we update manifest modtime between writes, and refresh manifest as well 
+
+   // TODO: test this-we update manifest modtime between writes, and refresh manifest as well
    SG_manifest_get_modtime( UG_inode_manifest( inode ), &manifest_mtime_sec, &manifest_mtime_nsec );
-   
+
    // are we the coordinator?
    if( SG_gateway_id( gateway ) == SG_manifest_get_coordinator( UG_inode_manifest( inode ) ) ) {
-      
+
       local_coordinator = true;
    }
-   
+
    // if we're the coordinator and we didn't explicitly mark the manifest as stale, then it's fresh
    if( !SG_manifest_is_stale( UG_inode_manifest( inode ) ) && local_coordinator ) {
-      
+
       // we're the coordinator--we already have the freshest version
-      SG_debug("Manifest %" PRIX64 ".%" PRId64 ".%d is locally-coordinated and not stale\n", file_id, manifest_mtime_sec, manifest_mtime_nsec ); 
+      SG_debug("Manifest %" PRIX64 ".%" PRId64 ".%d is locally-coordinated and not stale\n", file_id, manifest_mtime_sec, manifest_mtime_nsec );
       fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return 0;
    }
 
    SG_debug("Reload manifest %" PRIX64 "/manifest.%" PRId64 ".%d (coordinator? %d)\n", file_id, manifest_mtime_sec, manifest_mtime_nsec, local_coordinator );
-   
+
    rc = clock_gettime( CLOCK_REALTIME, &now );
    if( rc != 0 ) {
-      
+
       rc = -errno;
       SG_error("clock_gettime rc = %d\n", rc );
-      
+
       fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return rc;
    }
-   
+
    // is the manifest stale?
    if( !SG_manifest_is_stale( UG_inode_manifest( inode ) ) && md_timespec_diff_ms( &now, &manifest_refresh_mtime ) <= max_read_freshness ) {
-      
+
       // still fresh
-      SG_debug("Manifest %" PRIX64 "/manifest.%" PRId64 ".%d is still fresh\n", file_id, manifest_mtime_sec, manifest_mtime_nsec ); 
+      SG_debug("Manifest %" PRIX64 "/manifest.%" PRId64 ".%d is still fresh\n", file_id, manifest_mtime_sec, manifest_mtime_nsec );
       fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return 0;
    }
-   
+
    // manifest is stale--must refresh.
    // get list of gateways to try
    rc = UG_read_download_gateway_list( gateway, coordinator_id, &gateway_ids_buf, &num_gateway_ids );
    if( rc != 0 ) {
-      
+
       fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return rc;
@@ -361,36 +361,36 @@ int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const
          SG_debug("   %" PRIu64 "\n", gateway_ids_buf[i] );
       }
    }
-   
-   // set up a request 
+
+   // set up a request
    rc = SG_request_data_init_manifest( gateway, fs_path, file_id, file_version, manifest_mtime_sec, manifest_mtime_nsec, &reqdat );
    if( rc != 0 ) {
-   
+
       SG_safe_free( gateway_ids_buf );
       fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return rc;
    }
-   
-   // get the manifest 
+
+   // get the manifest
    rc = UG_consistency_manifest_download( gateway, &reqdat, coordinator_id, gateway_ids_buf, num_gateway_ids, &new_manifest );
    SG_safe_free( gateway_ids_buf );
-   
+
    if( rc != 0 ) {
-      
-      SG_error("UG_consistency_manifest_download(%" PRIX64 ".%" PRId64 "/manifest.%ld.%ld) rc = %d\n", 
+
+      SG_error("UG_consistency_manifest_download(%" PRIX64 ".%" PRId64 "/manifest.%ld.%ld) rc = %d\n",
                reqdat.file_id, reqdat.file_version, reqdat.manifest_timestamp.tv_sec, reqdat.manifest_timestamp.tv_nsec, rc );
-      
+
       SG_request_data_free( &reqdat );
-      fskit_entry_unlock( fent ); 
+      fskit_entry_unlock( fent );
       fskit_entry_unref( fs, fs_path, fent );
       return rc;
    }
-   
+
    // merge in new blocks (but keep locally-dirty ones)
    rc = UG_inode_manifest_merge_blocks( gateway, inode, &new_manifest );
    if( rc == 0 ) {
-      
+
       // restore modtime, version, coordinator, size
       SG_manifest_set_modtime( UG_inode_manifest( inode ), SG_manifest_get_modtime_sec( &new_manifest ), SG_manifest_get_modtime_nsec( &new_manifest ) );
       SG_manifest_set_coordinator_id( UG_inode_manifest( inode ), SG_manifest_get_coordinator( &new_manifest ) );
@@ -402,28 +402,28 @@ int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const
       else {
          UG_inode_set_size( inode, MAX( SG_manifest_get_file_size( &new_manifest ), UG_inode_size( inode ) ) );
       }
-         
+
       SG_manifest_set_file_version( UG_inode_manifest( inode ), SG_manifest_get_file_version( &new_manifest ) );
 
-      // update refresh time 
+      // update refresh time
       rc = clock_gettime( CLOCK_REALTIME, &now );
       if( rc != 0 ) {
-         
+
          rc = -errno;
          SG_error("clock_gettime rc = %d\n", rc );
-         
+
          // mask--the worst that'll happen is we refresh too much
          rc = 0;
       }
       else {
-         
+
          // advance refresh time
          UG_inode_set_manifest_refresh_time_now( inode );
       }
    }
    else {
- 
-      SG_error("UG_inode_manifest_merge_blocks( %" PRIX64 ".%" PRId64 "/manifest.%ld.%ld ) rc = %d\n", 
+
+      SG_error("UG_inode_manifest_merge_blocks( %" PRIX64 ".%" PRId64 "/manifest.%ld.%ld ) rc = %d\n",
                 reqdat.file_id, reqdat.file_version, reqdat.manifest_timestamp.tv_sec, reqdat.manifest_timestamp.tv_nsec, rc );
 
    }
@@ -434,7 +434,7 @@ int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const
    fskit_entry_unref( fs, fs_path, fent );
    SG_manifest_free( &new_manifest );
    SG_request_data_free( &reqdat );
-   
+
    return rc;
 }
 
@@ -442,72 +442,72 @@ int UG_consistency_manifest_ensure_fresh( struct SG_gateway* gateway, char const
 // replace one fskit_entry with another.
 // deferred-delete the old fent.
 // return 0 on success
-// return -errno on failure 
+// return -errno on failure
 // return EAGAIN if we successfully attached, but failed to remove the old fent
-// NOTE: fent must be write-locked 
+// NOTE: fent must be write-locked
 static int UG_consistency_fskit_entry_replace( struct SG_gateway* gateway, char const* fs_path, struct fskit_entry* parent, struct fskit_entry* fent, struct fskit_entry* new_fent ) {
-   
+
    int rc = 0;
 
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    char* basename = fskit_basename( fs_path, NULL );
-   if( basename == NULL ) { 
+   if( basename == NULL ) {
        return -ENOMEM;
    }
-   
+
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    struct md_syndicate_cache* cache = SG_gateway_cache( gateway );
-   
+
    // blow away this file/directory and its children
    rc = UG_deferred_remove( ug, fs_path, fent );
    if( rc != 0 ) {
-      
+
       SG_error("UG_deferred_remove( '%s' ) rc = %d\n", fs_path, rc );
-      
+
       fskit_entry_destroy( fs, new_fent, false );
       SG_safe_free( new_fent );
       SG_safe_free( basename );
-      
+
       return rc;
    }
-   
+
    // put the new one in place
    rc = fskit_entry_attach_lowlevel( parent, new_fent, basename );
    SG_safe_free( basename );
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("fskit_entry_attach_lowlevel( '%s' ) rc = %d\n", fs_path, rc );
-      
+
       // NOTE: don't try to reinsert--the old one was gone either way
       fskit_entry_destroy( fs, new_fent, false );
       SG_safe_free( new_fent );
-      
+
       return rc;
    }
-   
+
    // blow away the inode's cached data
    // (NOTE: don't care if this fails--it'll get reaped eventually)
    md_cache_evict_file( cache, fskit_entry_get_file_id( fent ), UG_inode_file_version( inode ), 0 );
-   
+
    UG_inode_free( inode );
    inode = NULL;
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("UG_deferred_remove('%s') rc = %d\n", fs_path, rc );
    }
-   
+
    return rc;
 }
 
 
 // reload a single inode's metadata.
 // * if the types don't match, the inode (and its children) will be dropped and a new inode with the new type will be created in its place.
-// * if the versions don't match, then the inode will be reversioned 
+// * if the versions don't match, then the inode will be reversioned
 // * for regular files, if the size changed, then the inode will be truncated (i.e. evicting blocks if the size shrank)
 // * if the names don't match, the name will be changed.
 // * if this is a regular file, and we're still the coordinator and the version has not changed, then no reload will take place (since we already have the latest information).
@@ -515,26 +515,26 @@ static int UG_consistency_fskit_entry_replace( struct SG_gateway* gateway, char 
 // NOTE: parent must be write-locked
 // NOTE: fent might be replaced--don't access it after calling this method.
 // return 0 on success
-// return 1 if fent got replaced 
+// return 1 if fent got replaced
 // return -ENOMEM on OOM
 // return -errno on error
 int UG_consistency_inode_reload( struct SG_gateway* gateway, char const* fs_path, struct fskit_entry* parent, struct fskit_entry* fent, char const* fent_name, struct md_entry* inode_data ) {
-   
+
    int rc = 0;
    struct fskit_entry* new_fent = NULL;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
    struct md_syndicate_cache* cache = SG_gateway_cache( gateway );
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
 
    // types don't match?
    if( !UG_inode_export_match_type( inode, inode_data ) ) {
-      
+
       SG_debug("%" PRIX64 ": old type = %d, new type = %d\n", inode_data->file_id, fskit_entry_get_type( UG_inode_fskit_entry( inode ) ), inode_data->type );
 
       // make a new fskit entry for this
@@ -542,65 +542,65 @@ int UG_consistency_inode_reload( struct SG_gateway* gateway, char const* fs_path
       if( new_fent == NULL ) {
          return -ENOMEM;
       }
-      
+
       // build the new fent
       rc = UG_inode_fskit_entry_init( fs, new_fent, parent, inode_data );
       if( rc != 0 ) {
-         
+
          SG_error("UG_inode_fskit_entry_init( '%s' (%" PRIX64 ") ) rc = %d\n", inode_data->name, inode_data->file_id, rc );
-         
-         // OOM 
+
+         // OOM
          fskit_entry_destroy( fs, new_fent, false );
          SG_safe_free( new_fent );
          return rc;
       }
-      
+
       // replace in parent
       rc = UG_consistency_fskit_entry_replace( gateway, fs_path, parent, fent, new_fent );
       if( rc != 0 ) {
-         
+
          SG_error("UG_consistency_fskit_entry_replace( '%s' ) rc = %d\n", fs_path, rc );
-         
+
          if( rc < 0 ) {
-            
-            // failed to attach 
+
+            // failed to attach
             struct UG_inode* new_inode = (struct UG_inode*)fskit_entry_get_user_data( new_fent );
-            
+
             fskit_entry_destroy( fs, new_fent, false );
             SG_safe_free( new_fent );
-            
+
             UG_inode_free( new_inode );
             SG_safe_free( new_inode );
-            
+
             return rc;
          }
          else {
-            
-            // failed to garbage-collect 
+
+            // failed to garbage-collect
             SG_error("LEAK: failed to garbage-collect old inode for '%s'.  Consider filing a bug report!\n", fs_path);
             rc = 0;
          }
       }
-      
+
       // if this is a file, it's manifest is stale--we'll want to reload the block information as well
       if( fskit_entry_get_type( new_fent ) == FSKIT_ENTRY_TYPE_FILE ) {
-         
+
          SG_manifest_set_stale( UG_inode_manifest( inode ), true );
          SG_debug("%" PRIX64 ": mark manifest stale\n", UG_inode_file_id( inode ) );
       }
-      
+
       // replaced!
       // nothing more to do--the new inode has the right version, name, and size
       UG_inode_set_refresh_time_now( inode );
       return 1;
    }
-   
+
    // versions don't match?
    if( !UG_inode_export_match_version( inode, inode_data ) ) {
-      
+
       // reversion--both metadata, and cached data, and staged data
       SG_debug("%" PRIX64 ": old version = %" PRId64 ", new version = %" PRId64 "\n", inode_data->file_id, UG_inode_file_version( inode ), inode_data->version );
-      
+
       // NOTE: don't really care if cache reversioning fails--it'll get reaped eventually
       md_cache_reversion_file( cache, inode_data->file_id, UG_inode_file_version( inode ), inode_data->version, 0 );
       SG_manifest_set_file_version( UG_inode_manifest( inode ), inode_data->version );
@@ -610,101 +610,101 @@ int UG_consistency_inode_reload( struct SG_gateway* gateway, char const* fs_path
       // if version matches and we're the coordinator, and this is a file, then no further action is necessary.
       if( SG_gateway_id( gateway ) == UG_inode_coordinator_id( inode ) ) {
 
-         // our copy is fresh if it's a file... 
+         // our copy is fresh if it's a file...
          SG_debug("%" PRIX64 " is coordinated locally\n", inode_data->file_id );
          UG_inode_set_refresh_time_now( inode );
          UG_inode_set_read_stale( inode, false );
-         
+
          return 0;
       }
    }
-   
+
    // file sizes don't match?
    if( fskit_entry_get_type( fent ) == FSKIT_ENTRY_TYPE_FILE && !UG_inode_export_match_size( inode, inode_data ) ) {
-      
+
       // need to expand/truncate inode
       off_t size = fskit_entry_get_size( UG_inode_fskit_entry( inode ) );
       off_t new_size = inode_data->size;
 
       SG_debug("%" PRIX64 ": old size = %jd, new size = %jd\n", inode_data->file_id, size, new_size );
-      
+
       if( size > new_size ) {
-         
+
          // shrunk
          uint64_t max_block_id = (new_size / block_size);
-         
+
          for( SG_manifest_block_iterator itr = SG_manifest_block_iterator_begin( UG_inode_manifest( inode ) ); itr != SG_manifest_block_iterator_end( UG_inode_manifest( inode ) ); itr++ ) {
-            
+
             if( SG_manifest_block_iterator_id( itr ) <= max_block_id ) {
                continue;
             }
-            
-            // NOTE: don't really care if these fail; they'll get reaped eventually 
+
+            // NOTE: don't really care if these fail; they'll get reaped eventually
             md_cache_evict_block_async( cache, UG_inode_file_id( inode ), UG_inode_file_version( inode ), SG_manifest_block_iterator_id( itr ), (SG_manifest_block_iterator_block( itr ))->block_version );
          }
-         
+
          SG_manifest_truncate( UG_inode_manifest( inode ), max_block_id );
       }
-      
+
       SG_manifest_set_size( UG_inode_manifest( inode ), new_size );
    }
-   
+
    // names don't match?
    if( UG_inode_export_match_name( inode, inode_data ) <= 0 ) {
-      
-      // inode got renamed 
+
+      // inode got renamed
       SG_debug("%" PRIX64 ": old name = '%s', new name = '%s'\n", inode_data->file_id, fent_name, inode_data->name );
 
       rc = fskit_entry_rename_in_directory( parent, fent, fent_name, inode_data->name );
       if( rc != 0 ) {
-         
-         // OOM 
+
+         // OOM
          SG_error("fskit_entry_rename_in_directory( '%s' ) rc = %d\n", inode_data->name, rc );
          return rc;
       }
    }
-   
+
    // manifest timestamps don't match, and we don't coordinate this file?
    if( fskit_entry_get_type( fent ) == FSKIT_ENTRY_TYPE_FILE && UG_inode_coordinator_id( inode ) != SG_gateway_id( gateway ) &&
       (inode_data->manifest_mtime_sec != SG_manifest_get_modtime_sec( UG_inode_manifest( inode ) ) || inode_data->manifest_mtime_nsec != SG_manifest_get_modtime_nsec( UG_inode_manifest( inode ) )) ) {
-      
+
       SG_debug("%" PRIX64 ": old manifest timestamp = %" PRId64 ".%d, new manifest timestamp = %" PRId64 ".%d\n", inode_data->file_id,
             SG_manifest_get_modtime_sec( UG_inode_manifest( inode ) ), SG_manifest_get_modtime_nsec( UG_inode_manifest( inode )),
             inode_data->manifest_mtime_sec, inode_data->manifest_mtime_nsec );
 
       SG_manifest_set_stale( UG_inode_manifest( inode ), true );
    }
-   
+
    // change of coordinator?
    if( UG_inode_coordinator_id( inode ) == SG_gateway_id( gateway ) && inode_data->coordinator != SG_gateway_id( gateway ) ) {
-      
+
       // uncache xattrs--we're not the authoritative source any longer
       SG_debug("%" PRIX64 ": old coordinator = %" PRIu64 ", new coordinator = %" PRIu64 "\n", inode_data->file_id, SG_gateway_id( gateway ), inode_data->coordinator );
 
       fskit_fremovexattr_all( fs, fent );
    }
-   
+
    // reload everything else
    SG_debug("Import '%s' (%" PRIX64 ")\n", inode_data->name, inode_data->file_id );
    rc = UG_inode_import( inode, inode_data );
    if( rc == 0 ) {
-      
+
       // reloaded!
       // no longer stale
       UG_inode_set_read_stale( inode, false );
       UG_inode_set_refresh_time_now( inode );
-      
+
       // only update the manifest refresh time if we're NOT the coordinator
-      if( fskit_entry_get_type( fent ) == FSKIT_ENTRY_TYPE_FILE && UG_inode_coordinator_id( inode ) != SG_gateway_id( gateway ) ) { 
-         
+      if( fskit_entry_get_type( fent ) == FSKIT_ENTRY_TYPE_FILE && UG_inode_coordinator_id( inode ) != SG_gateway_id( gateway ) ) {
+
          SG_manifest_set_modtime( UG_inode_manifest( inode ), inode_data->manifest_mtime_sec, inode_data->manifest_mtime_nsec );
       }
    }
    else {
-      
+
       SG_error("UG_inode_import( '%s' (%" PRIX64 ") ) rc = %d\n", inode_data->name, inode_data->file_id, rc );
    }
-   
+
    return rc;
 }
 
@@ -714,33 +714,33 @@ int UG_consistency_inode_reload( struct SG_gateway* gateway, char const* fs_path
 // destroys graft_parent and all of its children.
 // always succeeds
 static int UG_consistency_fskit_path_graft_free( struct fskit_core* fs, struct fskit_entry* graft_parent, struct md_entry* path_data, size_t path_len ) {
-   
+
    if( graft_parent == NULL ) {
       return 0;
    }
-   
+
    struct fskit_entry* graft_child = NULL;
    int i = 0;
-   
+
    while( (unsigned)i < path_len ) {
-      
-      // search graft parent 
+
+      // search graft parent
       graft_child = fskit_dir_find_by_name( graft_parent, path_data[i].name );
       if( graft_child == NULL ) {
-         
-         // done 
+
+         // done
          break;
       }
-      
-      // destroy graft parent 
+
+      // destroy graft parent
       fskit_entry_destroy( fs, graft_parent, false );
       SG_safe_free( graft_parent );
-      
+
       graft_parent = graft_child;
-      
+
       i++;
    }
-   
+
    return 0;
 }
 
@@ -754,118 +754,118 @@ static int UG_consistency_fskit_path_graft_free( struct fskit_core* fs, struct f
 // return -ENOMEM on OOM
 // NOTE: don't destroy path_data just yet--keep it around so we know how to look up and free the graft later on, if need be
 static int UG_consistency_fskit_path_graft_build( struct SG_gateway* gateway, ms_path_t* remote_path, struct md_entry* path_data, size_t path_len, struct fskit_entry** graft_root ) {
-   
+
    int rc = 0;
-   
+
    struct fskit_entry* graft_parent = NULL;
    struct fskit_entry* graft_child = NULL;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
    struct UG_inode* inode = NULL;
-   
+
    fskit_xattr_set* xattrs = NULL;
    fskit_xattr_set* old_xattrs = NULL;
-   
+
    // sanity check--all path_data elements except the leaf must be directories
    for( int i = 0; i < (int)path_len - 1; i++ ) {
-      
+
       if( path_data[i].type != MD_ENTRY_DIR ) {
-         
+
          return -EINVAL;
       }
    }
-   
+
    for( size_t i = 0; i < path_len; i++ ) {
-      
-      // next child 
+
+      // next child
       graft_child = fskit_entry_new();
       if( graft_child == NULL ) {
-         
+
          rc = -ENOMEM;
-         
+
          if( *graft_root != NULL ) {
             UG_consistency_fskit_path_graft_free( fs, *graft_root, path_data, path_len );
          }
-         
+
          return rc;
       }
-      
+
       SG_debug("Graft %s %" PRIX64 "\n", (path_data[i].type == MD_ENTRY_DIR ? "directory" : "file"), path_data[i].file_id );
-      
+
       // build the inode
       rc = UG_inode_fskit_entry_init( fs, graft_child, graft_parent, &path_data[i] );
       if( rc != 0 ) {
-         
+
          SG_error("UG_inode_fskit_entry_init( %" PRIX64 " (%s) ) rc = %d\n", path_data[i].file_id, path_data[i].name, rc );
-         
+
          if( *graft_root != NULL ) {
             UG_consistency_fskit_path_graft_free( fs, *graft_root, path_data, path_len );
          }
-        
+
          return rc;
       }
-      
+
       inode = (struct UG_inode*)fskit_entry_get_user_data( graft_child );
-      
+
       if( path_data[i].type == MD_ENTRY_FILE ) {
-          
+
           // file manifest should be stale, since we only have metadata
           SG_manifest_set_stale( UG_inode_manifest( inode ), true );
           SG_debug("%" PRIX64 ": mark manifest stale\n", UG_inode_file_id( inode ) );
       }
       else {
-          
-          // directory children should be stale, since we only have metadata 
+
+          // directory children should be stale, since we only have metadata
           struct timespec zero;
           memset( &zero, 0, sizeof(struct timespec) );
-          
+
           UG_inode_set_children_refresh_time( inode, &zero );
       }
-      
-      // metadata is fresh 
+
+      // metadata is fresh
       UG_inode_set_read_stale( inode, false );
       UG_inode_set_refresh_time_now( inode );
-      
-      // transfer xattrs 
+
+      // transfer xattrs
       xattrs = (fskit_xattr_set*)ms_client_path_ent_get_cls( &remote_path->at(i) );
       if( xattrs != NULL ) {
-          
+
           old_xattrs = fskit_entry_swap_xattrs( graft_child, xattrs );
-          
+
           if( old_xattrs != NULL ) {
               fskit_xattr_set_free( old_xattrs );
               old_xattrs = NULL;
           }
       }
-      
+
       ms_client_path_ent_set_cls( &remote_path->at(i), NULL );
-      
+
       // insert the inode into its parent (except for the root, which we'll do later)
       if( graft_parent != NULL ) {
-            
+
          rc = fskit_entry_attach_lowlevel( graft_parent, graft_child, path_data[i].name );
          if( rc != 0 ) {
-            
+
             SG_error("fskit_entry_attach_lowlevel( %" PRIX64 " --> %" PRIX64 " (%s) ) rc = %d\n", fskit_entry_get_file_id( graft_parent ), path_data[i].file_id, path_data[i].name, rc );
-            
+
             fskit_entry_destroy( fs, graft_child, false );
             UG_consistency_fskit_path_graft_free( fs, *graft_root, path_data, path_len );
             return rc;
          }
       }
-      
-      // set *graft_root if this is the first 
+
+      // set *graft_root if this is the first
       if( i == 0 ) {
-         
+
          *graft_root = graft_child;
       }
-      
+
       // next entry
       graft_parent = graft_child;
       graft_child = NULL;
    }
-   
+
    // success!
    return 0;
 }
@@ -873,103 +873,103 @@ static int UG_consistency_fskit_path_graft_build( struct SG_gateway* gateway, ms
 
 // attach a graft to an fskit_entry, based on its parent's ID and the path that the graft was generated from.
 // return 0 on success
-// return -ENOENT if the parent could not be found 
-// return -EEXIST if there is an existing entry with graft_root's name 
+// return -ENOENT if the parent could not be found
+// return -EEXIST if there is an existing entry with graft_root's name
 // return -ENOTDIR if the parent is not a directory
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 static int UG_consistency_fskit_path_graft_attach( struct SG_gateway* gateway, char const* fs_path, uint64_t parent_id, char const* graft_root_name, struct fskit_entry* graft_root ) {
-   
+
    int rc = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    bool attached = false;
-   
+
    struct fskit_path_iterator* itr = NULL;
-   
+
    if( graft_root == NULL ) {
       return -EINVAL;
    }
-   
+
    // find the attachment point
    itr = fskit_path_begin( fs, fs_path, true );
    if( itr == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    for( ; !fskit_path_end( itr ); fskit_path_next( itr ) ) {
-      
-      // current entry 
+
+      // current entry
       struct fskit_entry* cur = fskit_path_iterator_entry( itr );
       struct fskit_entry* collision = NULL;
-      
+
       if( fskit_entry_get_file_id( cur ) == parent_id ) {
-         
-         // has to be a dir 
+
+         // has to be a dir
          if( fskit_entry_get_type( cur ) != FSKIT_ENTRY_TYPE_DIR ) {
-            
+
             rc = -ENOTDIR;
             break;
          }
-         
+
          // graft point exists already?
          collision = fskit_dir_find_by_name( cur, graft_root_name );
          if( collision != NULL ) {
-            
-            // exists 
+
+            // exists
             char* tmppath = fskit_path_iterator_path( itr );
             SG_error("Directory '%s' has child '%s' already!\n", tmppath, graft_root_name );
             SG_safe_free( tmppath );
-            
+
             rc = -EEXIST;
             break;
          }
-         
+
          // attach!
          rc = fskit_entry_attach_lowlevel( cur, graft_root, graft_root_name );
-         
+
          if( rc == 0 ) {
             attached = true;
          }
-         
+
          break;
       }
    }
-   
+
    // done with this iterator
    fskit_path_iterator_release( itr );
-   
+
    if( rc == 0 && !attached ) {
-      
-      // that's odd--no point to attach to 
+
+      // that's odd--no point to attach to
       rc = -ENOENT;
    }
-   
+
    return rc;
 }
 
 
 // free a path's associated path contexts, and unref its entries
-// return 0 on success 
+// return 0 on success
 static int UG_consistency_path_free( struct fskit_core* core, ms_path_t* path ) {
-    
-    // unref all 
+
+    // unref all
     for( unsigned int i = 0; i < path->size(); i++ ) {
-        
+
         struct UG_path_ent_ctx* ent_ctx = (struct UG_path_ent_ctx*)ms_client_path_ent_get_cls( &path->at(i) );
         if( ent_ctx == NULL ) {
             continue;
         }
-        
+
         fskit_entry_unref( core, ent_ctx->fs_path, ent_ctx->fent );
         SG_safe_free( ent_ctx->fs_path );
         SG_safe_free( ent_ctx );
-        
+
         ms_client_path_ent_set_cls( &path->at(i), NULL );
     }
-    
+
     ms_client_free_path( path, NULL );
     return 0;
 }
@@ -978,103 +978,103 @@ static int UG_consistency_path_free( struct fskit_core* core, ms_path_t* path ) 
 // build up an ms_path_t of locally-cached but stale fskit entries.
 // for each entry in path_local, bind the associated the fskit entry to the path.
 // NOTE: path_local is not guaranteed to be a contiguous path--we will skip fresh entries
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 static int UG_consistency_path_find_local_stale( struct SG_gateway* gateway, char const* fs_path, struct timespec* refresh_begin, ms_path_t* path_local ) {
-   
+
    int rc = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    struct fskit_path_iterator* itr = NULL;
-   
+
    itr = fskit_path_begin( fs, fs_path, true );
    if( itr == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    for( ; !fskit_path_end( itr ); fskit_path_next( itr ) ) {
-      
+
       struct fskit_entry* cur = fskit_path_iterator_entry( itr );
       struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( cur );
-      
+
       struct ms_path_ent path_ent;
       struct UG_path_ent_ctx* path_ctx = NULL;  // remember the entries we reference
-      
+
       // is this inode stale?
       if( !UG_inode_is_read_stale( inode, refresh_begin ) ) {
-         
+
          char* name = fskit_path_iterator_name( itr );
          SG_debug("fresh: '%s' /%" PRIu64 "/%" PRIX64 ".%" PRId64 ", %" PRId64 "\n", name, UG_inode_volume_id( inode ), UG_inode_file_id( inode ), UG_inode_file_version( inode ), UG_inode_write_nonce( inode ) );
          SG_safe_free( name );
-   
+
          continue;
       }
       else {
-         
+
          char* name = fskit_path_iterator_name( itr );
          struct timespec refresh_time = UG_inode_refresh_time( inode );
-         
+
          SG_debug("stale: '%s' /%" PRIu64 "/%" PRIX64 ".%" PRId64 ", %" PRId64 " (mtime: %" PRId64 ".%ld, refresh_begin: %" PRId64 ".%ld, diff = %" PRId64 ", max = %d, is_stale = %d)\n",
                   name, UG_inode_volume_id( inode ), UG_inode_file_id( inode ), UG_inode_file_version( inode ), UG_inode_write_nonce( inode ),
                   refresh_time.tv_sec, refresh_time.tv_nsec, refresh_begin->tv_sec, refresh_begin->tv_nsec, md_timespec_diff_ms( refresh_begin, &refresh_time ),
                   UG_inode_max_read_freshness( inode ), UG_inode_is_read_stale( inode, NULL ) );
-         
+
          SG_safe_free( name );
       }
-      
+
       path_ctx = SG_CALLOC( struct UG_path_ent_ctx, 1 );
       if( path_ctx == NULL ) {
          rc = -ENOMEM;
          break;
       }
-      
+
       char* cur_path = fskit_path_iterator_path( itr );
       if( cur_path == NULL ) {
          SG_safe_free( path_ctx );
          rc = -ENOMEM;
          break;
       }
-      
-      // keep this fent around 
+
+      // keep this fent around
       fskit_entry_ref_entry( cur );
-      
+
       path_ctx->fent = cur;
       path_ctx->fs_path = cur_path;
-      
+
       rc = ms_client_getattr_request( &path_ent, UG_inode_volume_id( inode ), UG_inode_file_id( inode ), UG_inode_file_version( inode ), UG_inode_write_nonce( inode ), path_ctx );
       if( rc != 0 ) {
-         
+
          // OOM
          SG_safe_free( path_ctx );
-         SG_safe_free( cur_path ); 
+         SG_safe_free( cur_path );
          break;
       }
-      
+
       try {
-         
+
          path_local->push_back( path_ent );
       }
       catch( bad_alloc& ba ) {
-         
+
          rc = -ENOMEM;
          SG_safe_free( path_ctx );
          SG_safe_free( cur_path );
          break;
       }
    }
-   
+
    // done with this iterator
    fskit_path_iterator_release( itr );
-   
+
    if( rc != 0 ) {
-       
-       // unref all 
+
+       // unref all
        UG_consistency_path_free( fs, path_local );
    }
-   
+
    return rc;
 }
 
@@ -1082,13 +1082,13 @@ static int UG_consistency_path_find_local_stale( struct SG_gateway* gateway, cha
 // reload cached stale metadata entries from inode data.
 // if the MS indicates that an inode got removed remotely, then delete the cached inode locally and all of its children (if it has any) and terminate.
 // NOTE: inode_data must be in the same order as the inodes that appear in fskit.
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 // return -EINVAL if the order of inode_data is out-of-whack with fskit
 static int UG_consistency_path_stale_reload( struct SG_gateway* gateway, char const* fs_path, ms_path_t* path_stale, struct md_entry* inode_data, size_t num_inodes ) {
-   
+
    int rc = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
    char* name = NULL;           // inode name in fskit
@@ -1097,30 +1097,30 @@ static int UG_consistency_path_stale_reload( struct SG_gateway* gateway, char co
    struct UG_inode* inode = NULL;
    char* cur_path = NULL;
    bool skip = false;
-   
+
    if( num_inodes == 0 ) {
       return 0;
    }
-   
+
    struct fskit_path_iterator* itr = NULL;
-   
-   // reload each stale inode 
+
+   // reload each stale inode
    itr = fskit_path_begin( fs, fs_path, true );
    if( itr == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    for( ; !fskit_path_end( itr ); fskit_path_next( itr ) ) {
-      
+
       struct fskit_entry* cur = fskit_path_iterator_entry( itr );
       char* cur_name = fskit_path_iterator_name( itr );
       struct fskit_entry* parent = fskit_path_iterator_entry_parent( itr );
-      
+
       file_id = fskit_entry_get_file_id( cur );
       inode = (struct UG_inode*)fskit_entry_get_user_data( cur );
-      
-      // if not stale, then skip 
+
+      // if not stale, then skip
       skip = true;
       for( unsigned int j = 0; j < path_stale->size(); j++ ) {
           if( path_stale->at(j).file_id == file_id ) {
@@ -1128,79 +1128,79 @@ static int UG_consistency_path_stale_reload( struct SG_gateway* gateway, char co
               break;
           }
       }
-      
+
       if( skip ) {
           // this inode is fresh
           SG_safe_free( cur_name );
           continue;
       }
-      
+
       if( inode_i >= num_inodes ) {
-         
+
          SG_error("overflow: counted %zu inodes\n", inode_i );
          SG_safe_free( cur_name );
          rc = -EINVAL;
          break;
       }
-      
-      // next datum 
+
+      // next datum
       struct md_entry* inode_datum = &inode_data[ inode_i ];
-      
+
       // is this the fskit entry to reload?
       if( file_id != inode_datum->file_id ) {
-         
+
          // nope--this one's fresh. dig deeper
          SG_debug("skip: '%s' (%" PRIX64 ")\n", cur_name, file_id );
          SG_safe_free( cur_name );
-         
+
          continue;
       }
-      
+
       SG_debug("Consider %" PRIX64 ".%" PRId64 ".%" PRId64 "\n",
                inode_data[inode_i].file_id, inode_data[inode_i].version, inode_data[inode_i].write_nonce );
-      
+
       // is there any change to reload?
       if( inode_datum->error == MS_LISTING_NOCHANGE ) {
-         
-         // nope--nothing to do 
+
+         // nope--nothing to do
          inode_i++;
-         
+
          // mark fresh
          UG_inode_set_read_stale( inode, false );
          UG_inode_set_refresh_time_now( inode );
-         
+
          /////////////////////////////////////
          SG_debug("No Change: '%s' (%" PRIX64 ")\n", cur_name, file_id );
          /////////////////////////////////////
-         
+
          SG_safe_free( cur_name );
          continue;
       }
-      
-              
+
+
       // does this inode exist on the MS?
       if( inode_datum->error == MS_LISTING_NONE ) {
-         
+
          SG_debug("Remove: '%s' (%" PRIu64 ")\n", inode_datum->name, inode_datum->file_id );
          SG_safe_free( cur_name );
-          
+
          // nope--this inode and everything beneath it got unlinked remotely
          // blow them all away locally
          char* path_stump = fskit_path_iterator_path( itr );
          if( path_stump == NULL ) {
-            
+
             rc = -ENOMEM;
             break;
          }
-         
+
          rc = UG_deferred_remove( ug, path_stump, cur );
          if( rc != 0 ) {
-            
+
             SG_error( "UG_deferred_remove('%s') rc = %d\n", path_stump, rc );
          }
-         
+
          SG_safe_free( path_stump );
-         
+
          // done iterating
          break;
       }
@@ -1208,14 +1208,14 @@ static int UG_consistency_path_stale_reload( struct SG_gateway* gateway, char co
       // name of this inode, in case it gets blown away?
       name = SG_strdup_or_null( inode_datum->name );
       if( name == NULL ) {
-         
+
          rc = -ENOMEM;
          SG_safe_free( cur_name );
-         
+
          break;
       }
-         
-      // reload 
+
+      // reload
       cur_path = fskit_path_iterator_path( itr );
       if( cur_path == NULL ) {
          rc = -ENOMEM;
@@ -1226,76 +1226,76 @@ static int UG_consistency_path_stale_reload( struct SG_gateway* gateway, char co
       SG_debug("Reload: '%s' (%" PRIu64 ")\n", cur_path, inode_datum->file_id );
       rc = UG_consistency_inode_reload( gateway, cur_path, parent, cur, cur_name, inode_datum );
       SG_safe_free( cur_name );
-   
+
       if( rc < 0 ) {
-         
+
          SG_error("UG_consistency_inode_reload( '%s' (at %" PRIX64 " (%s))) rc = %d\n", cur_path, fskit_entry_get_file_id( cur ), name, rc );
-         
+
          SG_safe_free( name );
          SG_safe_free( cur_path );
-         
+
          break;
       }
-      
+
       SG_safe_free( cur_path );
-      
+
       if( rc > 0 ) {
-      
+
          // cur got replaced.
-         // reload it 
+         // reload it
          cur = fskit_dir_find_by_name( parent, name );
-         
+
          if( cur == NULL ) {
-            
+
             // not found--this and all inodes beneath us are gone
             SG_safe_free( name );
-            
+
             rc = -ENOENT;
             break;
          }
       }
-      
+
       SG_safe_free( name );
-      
+
       // success!  next entry
       inode_i++;
    }
-   
+
    // done iterating
    fskit_path_iterator_release( itr );
-   
+
    return rc;
 }
 
 
 // build up a path of download requests for remote entries
 // return 0 on success, and fill in *path_remote with remote inode data (could be empty)
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 static int UG_consistency_path_find_remote( struct SG_gateway* gateway, char const* fs_path, ms_path_t* path_remote ) {
 
    int rc = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    struct UG_inode* inode = NULL;
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t volume_id = ms_client_get_volume_id( ms );
-   
+
    struct fskit_path_iterator* itr = NULL;
-   
+
    struct ms_path_ent deepest_ent;
    uint64_t deepest_ent_parent_id = 0;
    uint64_t deepest_ent_file_id = 0;
    char* remote_head = NULL;
    int itr_error = 0;
    int depth = 0;
-   
+
    char** names = NULL;
 
    // in order to build up the contents of path_remote, we need
-   // the first entry of path_remote to have information known 
+   // the first entry of path_remote to have information known
    // to the deepest known fskit entry (volume_id, file_id, name, parent_id).
    // the remaining entries only need names and volume_id.
    // find this parent, and populate it.
@@ -1304,116 +1304,116 @@ static int UG_consistency_path_find_remote( struct SG_gateway* gateway, char con
    if( itr == NULL ) {
       return -ENOMEM;
    }
-   
+
    for( ; !fskit_path_end( itr ); fskit_path_next( itr ) ) {
-      
+
       struct fskit_entry* cur = fskit_path_iterator_entry( itr );
-      
+
       inode = (struct UG_inode*)fskit_entry_get_user_data( cur );
-      
+
       deepest_ent_parent_id = deepest_ent_file_id;
       deepest_ent_file_id = UG_inode_file_id( inode );
-      
+
       depth++;
    }
-   
+
    itr_error = fskit_path_iterator_error( itr );
-   
+
    // done iterating
    fskit_path_iterator_release( itr );
-   
+
    // failed?
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    // should have hit ENOENT if we had anything remote
    if( itr_error == 0 ) {
-      
+
       // nothing to do!
       return 0;
    }
    else if( itr_error != -ENOENT ) {
-      
+
       // some other error...
       SG_error("fskit_path_iterator_error('%s') rc = %d\n", fs_path, itr_error );
       return itr_error;
    }
-   
-   // build the head of the remote path 
-   // the first name is the first non-local entry 
+
+   // build the head of the remote path
+   // the first name is the first non-local entry
    remote_head = SG_strdup_or_null( fs_path );
    if( remote_head == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    rc = fskit_path_split( remote_head, &names );
    if( rc != 0 ) {
-      
+
       SG_safe_free( remote_head );
       return -ENOMEM;
    }
-   
+
    // head is the deepest local entry, who's child is remote
    rc = ms_client_path_download_ent_head( &deepest_ent, volume_id, deepest_ent_file_id, deepest_ent_parent_id, names[depth-1], NULL );
-   
+
    if( rc != 0 ) {
-      
-      // OOM 
+
+      // OOM
       SG_safe_free( remote_head );
       SG_safe_free( names );
       return rc;
    }
-   
+
    try {
-      
+
       path_remote->push_back( deepest_ent );
    }
    catch( bad_alloc& ba ) {
-      
+
       ms_client_free_path_ent( &deepest_ent, NULL );
       SG_safe_free( remote_head );
       SG_safe_free( names );
       return -ENOMEM;
    }
-   
+
    // build the tail
    for( size_t i = depth; names[i] != NULL; i++ ) {
-      
+
       struct ms_path_ent ms_ent;
-      
+
       // skip .
       if( strcmp(names[i], ".") == 0 ) {
          continue;
       }
-      
+
       rc = ms_client_path_download_ent_tail( &ms_ent, volume_id, names[i], NULL );
       if( rc != 0 ) {
-         
+
          ms_client_free_path( path_remote, NULL );
          SG_safe_free( remote_head );
          SG_safe_free( names );
          return rc;
       }
-      
+
       try {
-         
+
          path_remote->push_back( ms_ent );
       }
       catch( bad_alloc& ba ) {
-         
+
          ms_client_free_path( path_remote, NULL );
          SG_safe_free( remote_head );
          SG_safe_free( names );
          return -ENOMEM;
       }
    }
-   
+
    SG_safe_free( remote_head );
    SG_safe_free( names );
-   
+
    // built!
    return 0;
 }
@@ -1422,23 +1422,23 @@ static int UG_consistency_path_find_remote( struct SG_gateway* gateway, char con
 // clean up a remote path entry:
 // * if it contains anything, it will be an fskit_xattr_set.  free it.
 static void UG_consistency_path_free_remote( void* cls ) {
-    
+
     if( cls != NULL ) {
-        
+
         fskit_xattr_set* xattrs = (fskit_xattr_set*)cls;
         fskit_xattr_set_free( xattrs );
     }
 }
 
 
-// merge unchanged path data into a multi-result 
-// always succeeds 
+// merge unchanged path data into a multi-result
+// always succeeds
 static void UG_consistency_path_merge_nochange( ms_path_t* path, struct ms_client_multi_result* result ) {
-    
+
     for( int i = 0; i < result->num_processed; i++ ) {
-        
+
         if( result->ents[i].error == MS_LISTING_NOCHANGE ) {
-            
+
             result->ents[i].file_id = path->at(i).file_id;
             result->ents[i].version = path->at(i).version;
             result->ents[i].write_nonce = path->at(i).write_nonce;
@@ -1451,95 +1451,95 @@ static void UG_consistency_path_merge_nochange( ms_path_t* path, struct ms_clien
 }
 
 
-// reload a path of metadata 
-// cached path entries will be revalidated--reloaded, or dropped if they are no longer present upstream 
-// un-cached path entries will be downloaded and grafted into the fskit filesystem 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// reload a path of metadata
+// cached path entries will be revalidated--reloaded, or dropped if they are no longer present upstream
+// un-cached path entries will be downloaded and grafted into the fskit filesystem
+// return 0 on success
+// return -ENOMEM on OOM
 // return -errno on failure to connect
 int UG_consistency_path_ensure_fresh( struct SG_gateway* gateway, char const* fs_path ) {
-   
+
    int rc = 0;
-   bool not_found = false;      // set if we get ENOENT on a remote path 
-   
+   bool not_found = false;      // set if we get ENOENT on a remote path
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    ms_path_t path_local;
    ms_path_t path_remote;
-   
+
    struct timespec refresh_start;
-   
+
    struct ms_client_multi_result remote_inodes_stale;           // for revalidating stale data
    struct ms_client_multi_result remote_inodes_downloaded;      // for fetching unexplored data
-   
+
    memset( &remote_inodes_stale, 0, sizeof(struct ms_client_multi_result) );
    memset( &remote_inodes_downloaded, 0, sizeof(struct ms_client_multi_result) );
-   
+
    struct fskit_entry* graft_root = NULL;
-   
+
    clock_gettime( CLOCK_REALTIME, &refresh_start );
-   
+
    // find all local stale nodes.
    // each entry in path_local will be bound to its ref'ed fskit_entry
    rc = UG_consistency_path_find_local_stale( gateway, fs_path, &refresh_start, &path_local );
    if( rc != 0 ) {
-      
+
       SG_error("UG_consistency_path_find_local_stale( '%s' ) rc = %d\n", fs_path, rc );
       return rc;
    }
-   
+
    SG_debug("Will fetch %zu stale inodes for '%s'\n", path_local.size(), fs_path );
-   
-   // refresh stale data 
+
+   // refresh stale data
    rc = ms_client_getattr_multi( ms, &path_local, &remote_inodes_stale );
-   
+
    if( rc != 0 && rc != -ENOENT ) {
-      
+
       UG_consistency_path_free( fs, &path_local );
-      
+
       SG_error("ms_client_getattr_multi('%s') rc = %d, MS reply error %d\n", fs_path, rc, remote_inodes_stale.reply_error );
       return rc;
    }
    else if( rc == -ENOENT ) {
-       
+
       not_found = true;
    }
-   
+
    // ensure that even for unchanged inodes, we have enough inode information to find and merge the fresh data into our cached tree.
    // UG_consistency_path_merge_nochange( &path_local, &remote_inodes_stale );
-   
+
    /////////////////////////////////////////////////////////////
-   
+
    SG_debug("Fetched %d stale inodes for '%s'\n", remote_inodes_stale.num_processed, fs_path );
    for( int i = 0; i < remote_inodes_stale.num_processed; i++ ) {
-      
+
       char* inode_str = NULL;
       if( remote_inodes_stale.ents[i].error == MS_LISTING_NEW ) {
          rc = md_entry_to_string( &remote_inodes_stale.ents[i], &inode_str );
          if( rc == 0 ) {
-            
+
             SG_debug("NEW entry %d:\n%s\n", i, inode_str );
             SG_safe_free( inode_str );
          }
       }
    }
-   
+
    /////////////////////////////////////////////////////////////
-   
-   // load downloaded inodes into the fskit filesystem tree 
+
+   // load downloaded inodes into the fskit filesystem tree
    if( remote_inodes_stale.num_processed > 0 ) {
-      
+
       // prune absent entries and reload still-existing ones
       rc = UG_consistency_path_stale_reload( gateway, fs_path, &path_local, remote_inodes_stale.ents, remote_inodes_stale.num_processed );
-      
+
       ms_client_multi_result_free( &remote_inodes_stale );
       UG_consistency_path_free( fs, &path_local );
-      
+
       if( rc != 0 ) {
-         
+
          SG_error("UG_consistency_path_stale_reload('%s') rc = %d\n", fs_path, rc );
          return rc;
       }
@@ -1548,98 +1548,98 @@ int UG_consistency_path_ensure_fresh( struct SG_gateway* gateway, char const* fs
        ms_client_multi_result_free( &remote_inodes_stale );
        UG_consistency_path_free( fs, &path_local );
    }
-   
+
    if( not_found ) {
-       
-       // done 
+
+       // done
        ms_client_multi_result_free( &remote_inodes_stale );
        return -ENOENT;
    }
-   
+
    // which inodes do we not have locally cached?
    rc = UG_consistency_path_find_remote( gateway, fs_path, &path_remote );
    if( rc != 0 ) {
-      
+
       SG_error("UG_consistency_path_find_remote('%s') rc = %d\n", fs_path, rc );
       return rc;
    }
-   
+
    SG_debug("Will fetch %zu remote inodes for '%s'\n", path_remote.size(), fs_path );
-   
+
    // are any remote?
    if( path_remote.size() == 0 ) {
-      
+
       // done!
       return 0;
    }
-   
+
    // fetch remote inodes
    rc = ms_client_path_download( ms, &path_remote, &remote_inodes_downloaded );
    if( rc != 0 && rc != -ENOENT ) {
-      
+
       ms_client_free_path( &path_remote, NULL );
       ms_client_multi_result_free( &remote_inodes_downloaded );
-      
+
       SG_error("ms_client_download_path('%s') rc = %d\n", fs_path, rc );
-      
+
       return rc;
    }
    else if( rc == -ENOENT ) {
-       
+
       not_found = true;
    }
-   
+
    // fetch the xattrs for all remote inodes we received for which we are the coordinator.
    // we will have received the xattr hash in the remote_inodes_downloaded.ents listing.
    // the xattrs in each case will be attached to path_remote's entries
    rc = UG_consistency_fetchxattrs_all( gateway, &path_remote, &remote_inodes_downloaded );
    if( rc != 0 ) {
-      
+
       ms_client_free_path( &path_remote, UG_consistency_path_free_remote );
       ms_client_multi_result_free( &remote_inodes_downloaded );
-      
+
       SG_error("UG_consistency_fetchxattrs_all('%s') rc = %d\n", fs_path, rc );
-      
+
       return rc;
    }
-   
+
    SG_debug("Fetched %d remote inode(s) for '%s'\n", remote_inodes_downloaded.num_processed, fs_path );
-   
+
    // build a graft from all absent entries downloaded, as well as any xattrs we just downloaded
    rc = UG_consistency_fskit_path_graft_build( gateway, &path_remote, remote_inodes_downloaded.ents, remote_inodes_downloaded.num_processed, &graft_root );
-   
+
    if( rc != 0 ) {
-      
+
       ms_client_free_path( &path_remote, UG_consistency_path_free_remote );
       ms_client_multi_result_free( &remote_inodes_downloaded );
-      
+
       SG_error("UG_consistency_fskit_path_graft_build('%s') rc = %d\n", fs_path, rc );
       return rc;
    }
-   
-   // graft absent inodes into fskit 
+
+   // graft absent inodes into fskit
    if( graft_root != NULL ) {
-            
+
        rc = UG_consistency_fskit_path_graft_attach( gateway, fs_path, path_remote.at(0).parent_id, remote_inodes_downloaded.ents[0].name, graft_root );
        if( rc != 0 ) {
-            
+
            ////////////////////////////////////////////////////////////////////
            SG_error("UG_consistency_fskit_path_graft_attach('%s' (at %" PRIX64 " (%s)) ) rc = %d\n", fs_path, fskit_entry_get_file_id( graft_root ), remote_inodes_downloaded.ents[0].name, rc );
            ////////////////////////////////////////////////////////////////////
-            
+
            UG_consistency_fskit_path_graft_free( fs, graft_root, remote_inodes_downloaded.ents, remote_inodes_downloaded.num_processed );
            ms_client_multi_result_free( &remote_inodes_downloaded );
-            
+
            ms_client_free_path( &path_remote, UG_consistency_path_free_remote );
-        
+
            return rc;
        }
    }
-   
+
    // finished!
    ms_client_free_path( &path_remote, NULL );
    ms_client_multi_result_free( &remote_inodes_downloaded );
-   
+
    if( not_found ) {
        return -ENOENT;
    }
@@ -1649,15 +1649,15 @@ int UG_consistency_path_ensure_fresh( struct SG_gateway* gateway, char const* fs
 }
 
 
-// refresh a single inode's metadata 
+// refresh a single inode's metadata
 // return 0 if the inode is already fresh, or is not changed remotely
 // return 1 if the inode was not fresh, but we fetched and merged the new data successfully
 // return -ESTALE if we were unable to remotely refresh the inode, and it was remotely stale
-// return -errno on failure 
+// return -errno on failure
 // inode->entry must NOT be locked
 int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* fs_path, struct UG_inode* inode ) {
 
-   int rc = 0; 
+   int rc = 0;
    ms_path_t ms_inode;
    uint64_t volume_id = 0;
    uint64_t file_id = 0;
@@ -1678,7 +1678,7 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
    char* fent_name = md_basename( fs_path, NULL );
 
    if( fent_name == NULL || fs_dirpath == NULL ) {
-      
+
       SG_safe_free( fent_name );
       SG_safe_free( fs_dirpath );
       return -ENOMEM;
@@ -1718,8 +1718,8 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
          return -ESTALE;
       }
    }
-   
- 
+
+
    rc = ms_client_getattr_request( &path_ent, volume_id, file_id, file_version, write_nonce, NULL);
    if( rc != 0 ) {
 
@@ -1728,7 +1728,7 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
       SG_safe_free( fs_dirpath );
       return rc;
    }
-   
+
    rc = ms_client_getattr( ms, &path_ent, &entry );
    if( rc != 0 ) {
 
@@ -1739,14 +1739,14 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
    }
 
    if( entry.error == MS_LISTING_NOCHANGE ) {
-      
+
       // we're fresh
       SG_safe_free( fent_name );
       SG_safe_free( fs_dirpath );
       md_entry_free( &entry );
       SG_debug("Entry %" PRIX64 " is fresh\n", file_id );
 
-      // mark as such if not intermittently changed 
+      // mark as such if not intermittently changed
       fskit_entry_wlock( UG_inode_fskit_entry(inode) );
 
       if( UG_inode_file_version(inode) == file_version && UG_inode_write_nonce(inode) == write_nonce && UG_inode_coordinator_id(inode) == coordinator_id ) {
@@ -1760,10 +1760,10 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
       return 0;
    }
 
-   // write-lock both the parent and child, so we can reload 
+   // write-lock both the parent and child, so we can reload
    dent = fskit_entry_resolve_path( fs, fs_dirpath, 0, 0, true, &rc );
    if( dent == NULL ) {
-      
+
       // this entry does not exist anymore...
       SG_safe_free( fent_name );
       SG_safe_free( fs_dirpath );
@@ -1774,14 +1774,14 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
    fent = fskit_dir_find_by_name( dent, fent_name );
    if( fent == NULL ) {
 
-      // not found 
+      // not found
       SG_safe_free( fent_name );
       SG_safe_free( fs_dirpath );
       md_entry_free( &entry );
       fskit_entry_unlock( dent );
 
       return -ENOENT;
-   } 
+   }
 
    fskit_entry_wlock( fent );
 
@@ -1789,7 +1789,7 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
 
    fskit_entry_unlock( fent );
    fskit_entry_unlock( dent );
-      
+
    SG_safe_free( fent_name );
    SG_safe_free( fs_dirpath );
    md_entry_free( &entry );
@@ -1799,7 +1799,7 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
       SG_error("UG_consistency_inode_reload(%" PRIX64 ") rc = %d\n", file_id, rc );
       return rc;
    }
-    
+
    return 1;
 }
 
@@ -1807,20 +1807,20 @@ int UG_consistency_inode_ensure_fresh( struct SG_gateway* gateway, char const* f
 // merge a list of md_entrys into an fskit_entry directory.
 // for conflicts, if a local entry is newer than the given cut-off, keep it.  Otherwise replace it.
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // NOTE: dent must be write-locked!
 static int UG_consistency_dir_merge( struct SG_gateway* gateway, char const* fs_path_dir, struct fskit_entry* dent, struct md_entry* ents, size_t num_ents, struct timespec* keep_cutoff ) {
-   
+
    int rc = 0;
    char* fs_path = NULL;
    size_t max_name_len = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
-   // set up the fs_path buffer 
+
+   // set up the fs_path buffer
    for( size_t i = 0; i < num_ents; i++ ) {
-      
+
       if( ents[i].name != NULL ) {
          size_t len = strlen( ents[i].name );
          if( len > max_name_len ) {
@@ -1828,100 +1828,100 @@ static int UG_consistency_dir_merge( struct SG_gateway* gateway, char const* fs_
          }
       }
    }
-   
+
    fs_path = SG_CALLOC( char, strlen(fs_path_dir) + 1 + max_name_len + 2 );
    if( fs_path == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    for( size_t i = 0; i < num_ents; i++ ) {
-      
+
       struct md_entry* ent = &ents[i];
-      
+
       if( ent->name == NULL ) {
          continue;
       }
-      
+
       struct fskit_entry* fent = fskit_dir_find_by_name( dent, ent->name );
-      
+
       int64_t ctime_sec = 0;
       int32_t ctime_nsec = 0;
-      
+
       struct timespec ctime;
-      
+
       if( fent != NULL ) {
-         
+
          fskit_fullpath( fs_path_dir, ent->name, fs_path );
-         
+
          fskit_entry_wlock( fent );
-         
+
          // do we replace?
          // when was this entry created?
          fskit_entry_get_ctime( fent, &ctime_sec, &ctime_nsec );
-         
+
          ctime.tv_sec = ctime_sec;
          ctime.tv_nsec = ctime_nsec;
-         
+
          if( md_timespec_diff_ms( &ctime, keep_cutoff ) < 0 ) {
-            
+
             // fent was created before the reload, and is in conflict.  reload
             rc = UG_consistency_inode_reload( gateway, fs_path, dent, fent, ent->name, ent );
             if( rc < 0 ) {
-               
+
                SG_error("UG_consistency_inode_reload('%s') rc = %d\n", fs_path, rc );
-               
+
                // try to soldier on...
                rc = 0;
-               
+
                fskit_entry_unlock( fent );
             }
             else if( rc == 0 ) {
-               
+
                // reloaded, but not replaced
                fskit_entry_unlock( fent );
             }
          }
-         
+
          else {
-            
+
             // preserve this entry
             fskit_entry_unlock( fent );
          }
       }
       else {
-         
-         // insert this entry 
+
+         // insert this entry
          fent = fskit_entry_new();
          if( fent == NULL ) {
-            
+
             rc = -ENOMEM;
             break;
          }
-        
-         SG_debug("Merge '%s' into '%s'\n", ent->name, fs_path_dir ); 
+
+         SG_debug("Merge '%s' into '%s'\n", ent->name, fs_path_dir );
          rc = UG_inode_fskit_entry_init( fs, fent, dent, ent );
          if( rc != 0 ) {
-            
+
             SG_error("UG_inode_fskit_entry_init('%s') rc = %d\n", fs_path, rc );
-            
+
             fskit_entry_destroy( fs, fent, false );
             SG_safe_free( fent );
             break;
          }
-         
+
          rc = fskit_entry_attach_lowlevel( dent, fent, ent->name );
          if( rc != 0 ) {
-            
+
             SG_error("fskit_entry_attach_lowlevel('%s', '%s') rc = %d\n", fs_path_dir, ent->name, rc );
-            
+
             fskit_entry_destroy( fs, fent, false );
             SG_safe_free( fent );
             break;
          }
       }
    }
-   
+
    SG_safe_free( fs_path );
    return rc;
 }
@@ -1932,126 +1932,126 @@ static int UG_consistency_dir_merge( struct SG_gateway* gateway, char const* fs_
 // return 0 on success
 // return -ENOMEM on OOM
 int UG_consistency_dir_ensure_fresh( struct SG_gateway* gateway, char const* fs_path ) {
-   
+
    int rc = 0;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
    struct UG_inode* inode = NULL;
-   
+
    uint64_t file_id = 0;
    int64_t num_children = 0;
    int64_t least_unknown_generation = 0;
-   int64_t max_read_freshness = 0;
+   int32_t max_read_freshness = 0;
    int64_t capacity = 0;
-   
+
    struct timespec now;
    struct timespec dir_refresh_time;
    struct timespec children_refresh_time;
-   
+
    struct ms_client_multi_result results;
    memset( &results, 0, sizeof(struct ms_client_multi_result) );
-   
+
    char const* method = NULL;
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    struct fskit_entry* dent = fskit_entry_resolve_path( fs, fs_path, 0, 0, true, &rc );
    if( dent == NULL ) {
-      
+
       return rc;
    }
-   
+
    rc = clock_gettime( CLOCK_REALTIME, &now );
    if( rc != 0 ) {
-      
+
       rc = -errno;
       fskit_entry_unlock( dent );
-      
+
       SG_error("clock_gettime rc = %d\n", rc );
       return rc;
    }
-   
-   
+
+
    inode = (struct UG_inode*)fskit_entry_get_user_data( dent );
-   
+
    dir_refresh_time = UG_inode_refresh_time( inode );
    max_read_freshness = UG_inode_max_read_freshness( inode );
    children_refresh_time = UG_inode_children_refresh_time( inode );
-   
+
    // is the inode's directory listing still fresh?
    if( md_timespec_diff_ms( &now, &dir_refresh_time ) <= max_read_freshness && md_timespec_diff_ms( &now, &children_refresh_time ) <= max_read_freshness ) {
-      
-      // still fresh 
+
+      // still fresh
       SG_debug("'%s' is fresh\n", fs_path );
       fskit_entry_unlock( dent );
       return 0;
    }
-   
+
    // stale--redownload
    file_id = fskit_entry_get_file_id( dent );
    num_children = UG_inode_ms_num_children( inode );
    least_unknown_generation = UG_inode_generation( inode );
    capacity = UG_inode_ms_capacity( inode );
-   
-   // reference dent--it must stick around 
+
+   // reference dent--it must stick around
    fskit_entry_ref_entry( dent );
-   
+
    fskit_entry_unlock( dent );
 
    // have we listed before?
    if( least_unknown_generation <= 1 ) {
-      
+
       // nope--full download
       method = "ms_client_listdir";
       rc = ms_client_listdir( ms, file_id, num_children, capacity, &results );
    }
    else {
-      
+
       method = "ms_client_diffdir";
       rc = ms_client_diffdir( ms, file_id, num_children, least_unknown_generation + 1, &results );
    }
-   
+
    if( rc < 0 ) {
-      
+
       SG_error("%s('%s') rc = %d\n", method, fs_path, rc );
       fskit_entry_unref( fs, fs_path, dent );
-      
+
       ms_client_multi_result_free( &results );
-      
+
       return rc;
    }
-   
+
    if( results.reply_error != 0 ) {
-      
+
       SG_error("%s('%s') reply_error = %d\n", method, fs_path, rc );
       fskit_entry_unref( fs, fs_path, dent );
-      
+
       ms_client_multi_result_free( &results );
-      
+
       return rc;
    }
-   
-   // re-acquire 
+
+   // re-acquire
    fskit_entry_wlock( dent );
-   
-   // load them in 
+
+   // load them in
    rc = UG_consistency_dir_merge( gateway, fs_path, dent, results.ents, results.num_ents, &now );
-   
+
    if( rc == 0 ) {
-      
-      // set refresh time 
+
+      // set refresh time
       UG_inode_set_children_refresh_time_now( inode );
    }
-   
+
    fskit_entry_unlock( dent );
-   
+
    ms_client_multi_result_free( &results );
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("UG_consistency_dir_merge('%s') rc = %d\n", fs_path, rc );
    }
-   
+
    fskit_entry_unref( fs, fs_path, dent );
    return rc;
 }
@@ -2059,39 +2059,39 @@ int UG_consistency_dir_ensure_fresh( struct SG_gateway* gateway, char const* fs_
 
 // fetch all xattrs for a file inode.
 // this is necessary for when we are the coordinator of the file, or are about to become it.
-// return 0 on success, and set *xattr_names, *xattr_values, and *xattr_value_lengths 
-// return -ENOMEM on OOM 
+// return 0 on success, and set *xattr_names, *xattr_values, and *xattr_value_lengths
+// return -ENOMEM on OOM
 // return -ENODATA if we failed to fetch the xattr bundle from the MS, for whatever reason
-// return -errno on network-level error 
+// return -errno on network-level error
 int UG_consistency_fetchxattrs( struct SG_gateway* gateway, uint64_t file_id, int64_t xattr_nonce, unsigned char* xattr_hash, fskit_xattr_set** ret_xattrs ) {
-   
+
    int rc = 0;
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t volume_id = ms_client_get_volume_id( ms );
-   
+
    char** xattr_names = NULL;
    char** xattr_values = NULL;
    size_t* xattr_value_lengths = NULL;
    fskit_xattr_set* xattr_set = NULL;
-   
+
    rc = ms_client_fetchxattrs( ms, volume_id, file_id, xattr_nonce, xattr_hash, &xattr_names, &xattr_values, &xattr_value_lengths );
    if( rc != 0 ) {
-      
+
       SG_error("ms_client_fetchxattrs(/%" PRIu64 "/%" PRIX64 ".%" PRId64 ") rc = %d\n", volume_id, file_id, xattr_nonce, rc );
       return -ENODATA;
    }
 
    if( xattr_names[0] == NULL ) {
-      // no xattrs 
+      // no xattrs
       *ret_xattrs = NULL;
       SG_FREE_LIST( xattr_names, free );
       SG_FREE_LIST( xattr_values, free );
       SG_safe_free( xattr_value_lengths );
       return 0;
    }
- 
+
    for( size_t i = 0; xattr_names[i] != NULL; i++ ) {
-  
+
       //////////////////////////////////////////////////////////////////
       char value_buf[25];
       memset( value_buf, 0, 25 );
@@ -2103,21 +2103,21 @@ int UG_consistency_fetchxattrs( struct SG_gateway* gateway, uint64_t file_id, in
 
       rc = fskit_xattr_set_insert( &xattr_set, xattr_names[i], xattr_values[i], xattr_value_lengths[i], 0 );
       if( rc != 0 ) {
-         SG_error("fskit_xattr_set_insert rc = %d\n", rc ); 
+         SG_error("fskit_xattr_set_insert rc = %d\n", rc );
          break;
       }
    }
-      
+
    SG_FREE_LIST( xattr_names, free );
    SG_FREE_LIST( xattr_values, free );
    SG_safe_free( xattr_value_lengths );
-   
+
    if( rc != 0 ) {
-      
+
       fskit_xattr_set_free( xattr_set );
       return rc;
    }
-   
+
    *ret_xattrs = xattr_set;
    return 0;
 }
@@ -2128,31 +2128,31 @@ int UG_consistency_fetchxattrs( struct SG_gateway* gateway, uint64_t file_id, in
 // we do not have the xattr hash for these nodes yet, so just go with the one from the signed MS entry we put there.
 // return 0 on success, and pair the fskit_xattr_set with each inode's data in the result.
 // return -ENOMEM on OOM
-// return -ENODATA if we failed to fetch the xattr bundle from the MS, for whatever reason 
-// return -errno on network-level error 
+// return -ENODATA if we failed to fetch the xattr bundle from the MS, for whatever reason
+// return -errno on network-level error
 static int UG_consistency_fetchxattrs_all( struct SG_gateway* gateway, ms_path_t* path_remote, struct ms_client_multi_result* remote_inodes ) {
-   
+
    int rc = 0;
    for( size_t i = 0; i < path_remote->size() && remote_inodes->num_processed > 0 && i < (unsigned)remote_inodes->num_processed; i++ ) {
-      
+
       fskit_xattr_set* xattrs = NULL;
-      
+
       // only do this if we're the coordinator, and if there is xattr data at all
       if( SG_gateway_id( gateway ) == remote_inodes->ents[i].coordinator && remote_inodes->ents[i].xattr_hash != NULL ) {
-         
+
          SG_debug("Fetch xattrs for %" PRIX64 ".%" PRId64 ".%" PRId64 "\n", remote_inodes->ents[i].file_id, remote_inodes->ents[i].version, remote_inodes->ents[i].xattr_nonce );
          rc = UG_consistency_fetchxattrs( gateway, (*path_remote)[i].file_id, remote_inodes->ents[i].xattr_nonce, remote_inodes->ents[i].xattr_hash, &xattrs );
          if( rc != 0 ) {
-             
+
              SG_error("UG_consistency_fetchxattrs(%" PRIX64 ") rc = %d\n", (*path_remote)[i].file_id, rc );
              return rc;
          }
-        
-         // associate the xattrs with this path entry 
+
+         // associate the xattrs with this path entry
          ms_client_path_ent_set_cls( &path_remote->at(i), xattrs );
       }
    }
-   
+
    return 0;
 }
 
@@ -2174,12 +2174,12 @@ int UG_consistency_request_refresh( struct SG_gateway* gateway, char const* fs_p
    struct UG_inode* inode = NULL;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    int64_t manifest_mtime_sec = 0;
    int32_t manifest_mtime_nsec = 0;
    uint64_t file_id = 0;
    int64_t file_version = 0;
-  
+
    fent = fskit_entry_resolve_path( fs, fs_path, 0, 0, false, &rc );
    if( fent == NULL ) {
       SG_error("fskit_entry_resolve_path('%s') rc = %d\n", fs_path, rc);
@@ -2190,64 +2190,64 @@ int UG_consistency_request_refresh( struct SG_gateway* gateway, char const* fs_p
    file_id = UG_inode_file_id( inode );
    file_version = UG_inode_file_version( inode );
 
-   // can't do this if we're the coordinator 
+   // can't do this if we're the coordinator
    if( SG_gateway_id( gateway ) == UG_inode_coordinator_id( inode ) ) {
       SG_error("We're the coordinator of '%s'\n", fs_path );
       fskit_entry_unlock( fent );
       return -EINVAL;
    }
-    
+
    SG_manifest_get_modtime( UG_inode_manifest( inode ), &manifest_mtime_sec, &manifest_mtime_nsec );
-   
+
    rc = SG_request_data_init_manifest( gateway, fs_path, UG_inode_file_id( inode ), UG_inode_file_version( inode ), manifest_mtime_sec, manifest_mtime_nsec, &reqdat );
    if( rc != 0 ) {
-      
+
       // OOM
       fskit_entry_unlock( fent );
       return rc;
    }
-   
+
    rc = SG_client_request_REFRESH_setup( gateway, &req, &reqdat, UG_inode_coordinator_id( inode ) );
    if( rc != 0 ) {
-      
-      // OOM 
+
+      // OOM
       fskit_entry_unlock( fent );
       SG_error("SG_client_request_REFRESH_setup('%s') rc = %d\n", fs_path, rc );
       SG_request_data_free( &reqdat );
       return rc;
    }
-   
+
    SG_request_data_free( &reqdat );
-   
+
    rc = SG_client_request_send( gateway, UG_inode_coordinator_id( inode ), &req, NULL, &reply );
    fskit_entry_unlock( fent );
 
    if( rc != 0 ) {
-      
-      // network error 
+
+      // network error
       SG_error("SG_client_request_send(REFRESH '%s') rc = %d\n", fs_path, rc );
-      
-      // timed out? retry 
+
+      // timed out? retry
       if( rc == -ETIMEDOUT ) {
          rc = -EAGAIN;
       }
-      
-      // propagate retries; everything else is remote I/O error 
+
+      // propagate retries; everything else is remote I/O error
       if( rc != -EAGAIN ) {
          rc = -EREMOTEIO;
       }
-      
+
       return rc;
    }
-   
+
    if( reply.error_code() != 0 ) {
-      
+
       // failed to process
       SG_error("SG_client_request_send(REFRESH '%s') reply error = %d\n", fs_path, rc );
       return reply.error_code();
    }
 
-   // success! update refresh-time 
+   // success! update refresh-time
    fent = fskit_entry_resolve_path( fs, fs_path, 0, 0, true, &rc );
    if( fent == NULL ) {
       SG_error("fskit_entry_resolve_path('%s') rc = %d\n", fs_path, rc);
@@ -2277,4 +2277,3 @@ int UG_consistency_request_refresh( struct SG_gateway* gateway, char const* fs_p
 UG_consistency_request_refresh_out:
    return rc;
 }
-

--- a/libsyndicate-ug/inode.cpp
+++ b/libsyndicate-ug/inode.cpp
@@ -19,48 +19,48 @@
 
 // UG-specific inode information, for fskit
 struct UG_inode {
-   
+
    char* name;                          // name of this inode (allowed, since Syndicate does not support links)
    struct SG_manifest manifest;         // latest manifest of this file's blocks (includes coordinator_id and file_version)
-   
+
    unsigned char ms_xattr_hash[ SHA256_DIGEST_LENGTH ]; // latest xattr hash
    int64_t generation;          // last-known generation number of this file
-   
+
    int64_t write_nonce;         // latest write nonce
    int64_t xattr_nonce;         // latest xattr nonce
-   
+
    struct timespec refresh_time;                // time of last refresh from the ms
    struct timespec write_refresh_time;          // time of last remote-fresh request to the file's coordinator
    struct timespec manifest_refresh_time;       // time of last manifest refresh
    struct timespec children_refresh_time;       // if this is a directory, this is the time the children were last reloaded
-   uint32_t max_read_freshness;         // how long since last refresh, in millis, this inode is to be considered fresh for reading
-   uint32_t max_write_freshness;        // how long since last refresh, in millis, this inode is to be considered fresh from a remote update (0 means "always fresh")
-   
+   int32_t max_read_freshness;         // how long since last refresh, in millis, this inode is to be considered fresh for reading
+   int32_t max_write_freshness;        // how long since last refresh, in millis, this inode is to be considered fresh from a remote update (0 means "always fresh")
+
    bool read_stale;     // if true, this file must be revalidated before the next read
    bool write_stale;    // if true, this file must be revalidated before the next write
    bool dirty;          // if true, then we need to flush data on fsync()
-   
+
    int64_t ms_num_children;     // the number of children the MS says this inode has
    int64_t ms_capacity;         // maximum index number of a child in the MS
-   
+
    bool vacuuming;              // if true, then we're currently vacuuming this file
    bool vacuumed;               // if true, then we've already tried to vacuum this file upon discovery (false means we should try again)
-   
+
    UG_dirty_block_map_t* dirty_blocks;  // set of locally-modified blocks that must be replicated, either on the next fsync() or last close()
-   
+
    struct SG_manifest replaced_blocks;  // set of blocks replaced by writes, that need to be garbage-collected (contains only metadata)
-   
+
    UG_inode_fsync_queue_t* sync_queue;  // queue of fsync requests on this inode
-   
-   struct fskit_entry* entry;           // the fskit entry that owns this inode 
-   
+
+   struct fskit_entry* entry;           // the fskit entry that owns this inode
+
    bool renaming;                       // if true, then this inode is in the process of getting renamed.  Concurrent renames will fail with EBUSY
    bool deleting;                       // if true, then this inode is in the process of being deleted.  Concurrent opens and stats will fail
    bool creating;                       // if true, then this inode is in the process of being created.  Truncate will be a no-op in this case.
 };
 
 
-// rlock an inode, using its fskit entry 
+// rlock an inode, using its fskit entry
 // this is meant for external API consumers, like other gateways.
 int UG_inode_rlock( struct UG_inode* inode ) {
     if( inode->entry == NULL ) {
@@ -69,8 +69,8 @@ int UG_inode_rlock( struct UG_inode* inode ) {
     return fskit_entry_rlock( inode->entry );
 }
 
-// wlock an inode, using its fskit entry 
-// this is meant for external API consumers, like other gateways 
+// wlock an inode, using its fskit entry
+// this is meant for external API consumers, like other gateways
 int UG_inode_wlock( struct UG_inode* inode ) {
    if( inode->entry == NULL ) {
       return -EINVAL;
@@ -79,8 +79,8 @@ int UG_inode_wlock( struct UG_inode* inode ) {
 }
 
 
-// unlock an inode, using its fskit entry 
-// this is meant for external API consumers, like other gateways 
+// unlock an inode, using its fskit entry
+// this is meant for external API consumers, like other gateways
 int UG_inode_unlock( struct UG_inode* inode ) {
    if( inode->entry == NULL ) {
       return -EINVAL;
@@ -89,17 +89,17 @@ int UG_inode_unlock( struct UG_inode* inode ) {
 }
 
 
-// initialize common inode data 
+// initialize common inode data
 // type should be MD_ENTRY_FILE or MD_ENTRY_DIR
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 static int UG_inode_init_common( struct UG_inode* inode, char const* name, int type ) {
-   
+
    memset( inode, 0, sizeof(struct UG_inode) );
-   
+
    inode->name = SG_strdup_or_null( name );
    if( inode->name == NULL ) {
-       
+
        if( name != NULL ) {
           return -ENOMEM;
        }
@@ -107,21 +107,21 @@ static int UG_inode_init_common( struct UG_inode* inode, char const* name, int t
           return -EINVAL;
        }
    }
-   
+
    // regular file?
    if( type == MD_ENTRY_FILE ) {
-         
-      // sync queue 
+
+      // sync queue
       inode->sync_queue = SG_safe_new( UG_inode_fsync_queue_t() );
       if( inode->sync_queue == NULL ) {
-         
+
          return -ENOMEM;
       }
-      
-      // dirty blocks 
+
+      // dirty blocks
       inode->dirty_blocks = SG_safe_new( UG_dirty_block_map_t() );
       if( inode->dirty_blocks == NULL ) {
-         
+
          SG_safe_delete( inode->sync_queue );
          return -ENOMEM;
       }
@@ -132,27 +132,27 @@ static int UG_inode_init_common( struct UG_inode* inode, char const* name, int t
 
 // initialize an inode, from an entry and basic data
 // entry must be write-locked
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 int UG_inode_init( struct UG_inode* inode, char const* name, struct fskit_entry* entry, uint64_t volume_id, uint64_t coordinator_id, int64_t file_version ) {
-   
+
    int rc = 0;
-   
+
    rc = UG_inode_init_common( inode, name, fskit_entry_get_type( entry ) == FSKIT_ENTRY_TYPE_FILE ? MD_ENTRY_FILE : MD_ENTRY_DIR );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
-   // manifest 
+
+   // manifest
    rc = SG_manifest_init( &inode->manifest, volume_id, coordinator_id, fskit_entry_get_file_id( entry ), file_version );
    if( rc != 0 ) {
-      
+
       SG_safe_delete( inode->sync_queue );
       SG_safe_delete( inode->dirty_blocks );
       return rc;
    }
-  
+
    SG_manifest_set_size( &inode->manifest, fskit_entry_get_size( entry ) );
 
    if( fskit_entry_get_type( entry ) == FSKIT_ENTRY_TYPE_FILE ) {
@@ -172,38 +172,38 @@ int UG_inode_init( struct UG_inode* inode, char const* name, struct fskit_entry*
 }
 
 
-// initialize an inode from an exported inode data and an fskit_entry 
+// initialize an inode from an exported inode data and an fskit_entry
 // NOTE: file ID in inode_data and fent must match, as must their types
 // the inode's manifest will be stale, since it currently has no data.
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 // return -EINVAL if the data is invalid (i.e. file IDs don't match, and such)
 // fent must be at least read-locked
 int UG_inode_init_from_export( struct UG_inode* inode, struct md_entry* inode_data, struct fskit_entry* fent ) {
-   
+
    int rc = 0;
    int type = fskit_entry_get_type( fent );
    uint64_t file_id = fskit_entry_get_file_id( fent );
-   
-   // ID sanity check 
+
+   // ID sanity check
    if( inode_data->file_id != file_id && inode_data->file_id > 0 ) {
       SG_error("inode_data->file_id == %" PRIX64 ", fent->file_id == %" PRIX64 "\n", inode_data->file_id, file_id );
       return -EINVAL;
    }
-   
-   // type sanity check 
+
+   // type sanity check
    if( type == FSKIT_ENTRY_TYPE_FILE && inode_data->type > 0 && inode_data->type != MD_ENTRY_FILE ) {
       SG_error("inode_data->type == %d, fent->type == %d\n", inode_data->type, type );
       return -EINVAL;
    }
-   
+
    if( type == FSKIT_ENTRY_TYPE_DIR && inode_data->type > 0 && inode_data->type != MD_ENTRY_DIR ) {
       SG_error("inode_data->type == %d, fent->type == %d\n", inode_data->type, type );
       return -EINVAL;
    }
-    
+
    /////////////////////////////////////
-   /* 
+   /*
    char* tmp = NULL;
    rc = md_entry_to_string( inode_data, &tmp );
    if( rc == 0 && tmp != NULL ) {
@@ -215,12 +215,12 @@ int UG_inode_init_from_export( struct UG_inode* inode, struct md_entry* inode_da
 
    rc = UG_inode_init( inode, inode_data->name, fent, inode_data->volume, inode_data->coordinator, inode_data->version );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    SG_manifest_set_modtime( &inode->manifest, inode_data->manifest_mtime_sec, inode_data->manifest_mtime_nsec );
-   
+
    inode->write_nonce = inode_data->write_nonce;
    inode->xattr_nonce = inode_data->xattr_nonce;
    inode->generation = inode_data->generation;
@@ -228,11 +228,11 @@ int UG_inode_init_from_export( struct UG_inode* inode, struct md_entry* inode_da
    inode->max_write_freshness = inode_data->max_write_freshness;
    inode->ms_num_children = inode_data->num_children;
    inode->ms_capacity = inode_data->capacity;
-   
+
    clock_gettime( CLOCK_REALTIME, &inode->refresh_time );
 
    SG_manifest_set_stale( &inode->manifest, true );
-   
+
    return 0;
 }
 
@@ -240,137 +240,137 @@ int UG_inode_init_from_export( struct UG_inode* inode, struct md_entry* inode_da
 // common fskit entry initialization from an exported inode
 // return 0 on success (always succeeds)
 int UG_inode_fskit_common_init( struct fskit_entry* fent, struct md_entry* inode_data ) {
-   
+
    struct timespec ts;
-   
+
    // set ctime, mtime
    ts.tv_sec = inode_data->mtime_sec;
    ts.tv_nsec = inode_data->mtime_nsec;
    fskit_entry_set_mtime( fent, &ts );
-   
+
    ts.tv_sec = inode_data->ctime_sec;
    ts.tv_nsec = inode_data->ctime_nsec;
    fskit_entry_set_ctime( fent, &ts );
-   
+
    // set size
    fskit_entry_set_size( fent, inode_data->size );
-   
+
    return 0;
 }
 
-// generate a new fskit entry for a directory 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// generate a new fskit entry for a directory
+// return 0 on success
+// return -ENOMEM on OOM
 // return -EINVAL if inode_data doesn't represent a file
 // fent must be write-locked
 static int UG_inode_fskit_dir_init( struct fskit_entry* fent, struct fskit_entry* parent, struct md_entry* inode_data ) {
-   
+
    int rc = 0;
-   
-   // sanity check 
+
+   // sanity check
    if( inode_data->type != MD_ENTRY_DIR ) {
       SG_error("Inode %" PRIX64 " is not a directory\n", inode_data->file_id);
       return -EINVAL;
    }
-   
+
    rc = fskit_entry_init_dir( fent, parent, inode_data->file_id, inode_data->owner, inode_data->volume, inode_data->mode );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    UG_inode_fskit_common_init( fent, inode_data );
-   
+
    return 0;
 }
 
-// generate a new fskit entry for a regular file 
+// generate a new fskit entry for a regular file
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if inode_data doesn't represent a file
 // fent must be write-locked
 static int UG_inode_fskit_file_init( struct fskit_entry* fent, struct md_entry* inode_data ) {
-   
+
    int rc = 0;
-   
-   // sanity 
+
+   // sanity
    if( inode_data->type != MD_ENTRY_FILE ) {
       return -EINVAL;
    }
-   
+
    rc = fskit_entry_init_file( fent, inode_data->file_id, inode_data->owner, inode_data->volume, inode_data->mode );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    UG_inode_fskit_common_init( fent, inode_data );
    return 0;
 }
 
 
-// build an fskit entry from an exported inode 
+// build an fskit entry from an exported inode
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // fent must be write-locked
 int UG_inode_fskit_entry_init( struct fskit_core* fs, struct fskit_entry* fent, struct fskit_entry* parent, struct md_entry* inode_data ) {
-   
+
    int rc = 0;
    struct UG_inode* inode = NULL;
-   
+
    // going from file to directory?
    if( inode_data->type == MD_ENTRY_FILE ) {
-      
+
       // turn the inode into a directory, and blow away the file's data
-      // set up the file 
+      // set up the file
       rc = UG_inode_fskit_file_init( fent, inode_data );
       if( rc != 0 ) {
-         
+
          SG_error("UG_inode_fskit_file_init('%s' (%" PRIX64 ")) rc = %d\n", inode_data->name, inode_data->file_id, rc );
          return rc;
       }
    }
    else {
-      
+
       // going to make a directory, and replace this file.
-      // set up the directory 
+      // set up the directory
       rc = UG_inode_fskit_dir_init( fent, parent, inode_data );
       if( rc != 0 ) {
-         
+
          SG_error("UG_inode_fskit_dir_init('%s' (%" PRIX64 ")) rc = %d\n", inode_data->name, inode_data->file_id, rc );
          return rc;
       }
    }
-   
+
    // build the inode
    inode = UG_inode_alloc( 1 );
    if( inode == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
-   // set up the inode 
+
+   // set up the inode
    rc = UG_inode_init_from_export( inode, inode_data, fent );
    if( rc != 0 ) {
-      
+
       SG_error("UG_inode_init_from_export('%s' (%" PRIX64 ")) rc = %d\n", inode_data->name, inode_data->file_id, rc );
-      
+
       SG_manifest_free( &inode->manifest );
       SG_safe_free( inode );
       return rc;
    }
-   
+
    // put the inode into the fent, and fent into inode
    UG_inode_bind_fskit_entry( inode, fent );
-   
+
    return 0;
-}     
+}
 
 // free an inode
 // NOTE: destroys its dirty blocks
 // always succeeds
 int UG_inode_free( struct UG_inode* inode ) {
-   
+
    SG_safe_free( inode->name );
    SG_safe_delete( inode->sync_queue );
 
@@ -382,7 +382,7 @@ int UG_inode_free( struct UG_inode* inode ) {
    SG_manifest_free( &inode->manifest );
    SG_manifest_free( &inode->replaced_blocks );
    memset( inode, 0, sizeof(struct UG_inode) );
-   
+
    return 0;
 }
 
@@ -391,44 +391,44 @@ int UG_inode_free( struct UG_inode* inode ) {
 // NOTE: inode->entry must be read-locked
 // return 0 on success
 // return -EINVAL if the inode is malformed (NOTE: indicates a bug!)
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int UG_file_handle_init( struct UG_file_handle* fh, struct UG_inode* inode, int flags ) {
-   
+
    if( inode->entry == NULL ) {
       return -EINVAL;
    }
-   
+
    fh->evicts = SG_safe_new( UG_inode_block_eviction_map_t() );
    if( fh->evicts == NULL ) {
       return -ENOMEM;
    }
-   
+
    fh->inode_ref = inode;
    fh->flags = flags;
-   
+
    return 0;
 }
 
 
-// free a file handle 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// free a file handle
+// return 0 on success
+// return -ENOMEM on OOM
 int UG_file_handle_free( struct UG_file_handle* fh ) {
-   
+
    SG_safe_delete( fh->evicts );
-   
+
    memset( fh, 0, sizeof(struct UG_file_handle) );
-   
+
    return 0;
 }
 
 
 // export all non-builtin xattrs for an inode.
 // return 0 on success, filling in *ret_xattr_names, *ret_xattr_values, and *ret_xattr_value_lengths if there are xattrs in this inode.
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // NOTE: inode->entry must be read-locked
 int UG_inode_export_xattrs( struct fskit_core* fs, struct UG_inode* inode, char*** ret_xattr_names, char*** ret_xattr_values, size_t** ret_xattr_value_lengths ) {
-   
+
    int rc = 0;
    size_t num_xattrs = 0;
    ssize_t xattr_list_len = 0;
@@ -437,49 +437,49 @@ int UG_inode_export_xattrs( struct fskit_core* fs, struct UG_inode* inode, char*
    size_t* xattr_value_lengths = NULL;
    char* xattr_list = NULL;
    char* xattr_ptr = NULL;
-   
+
    xattr_list_len = fskit_xattr_flistxattr( fs, inode->entry, NULL, 0 );
    if( xattr_list_len < 0 ) {
-      
+
       SG_error("fskit_flistxattr(NULL) rc = %zd\n", xattr_list_len );
       return (int)xattr_list_len;
    }
-  
-   SG_debug("xattr_list_len = %zd\n", xattr_list_len ); 
+
+   SG_debug("xattr_list_len = %zd\n", xattr_list_len );
    if( xattr_list_len == 0 ) {
-       
+
       // no xattrs
       *ret_xattr_names = NULL;
       *ret_xattr_values = NULL;
       *ret_xattr_value_lengths = NULL;
       return 0;
    }
-       
+
    // get the list of xattrs
    xattr_list = SG_CALLOC( char, xattr_list_len );
    if( xattr_list == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    rc = fskit_xattr_flistxattr( fs, inode->entry, xattr_list, xattr_list_len );
    if( rc < 0 ) {
-      
+
       SG_error( "fskit_flistxattr(%zd) rc = %d\n", xattr_list_len, rc );
       return rc;
    }
-   
+
    // how many xattrs?
    for( ssize_t i = 0; i < xattr_list_len; i++ ) {
-      
+
       if( xattr_list[i] == '\0' ) {
          num_xattrs++;
       }
    }
 
-   SG_debug("num_xattrs = %zu\n", num_xattrs); 
+   SG_debug("num_xattrs = %zu\n", num_xattrs);
    if( num_xattrs == 0 ) {
-      // trivial case: no xattrs 
+      // trivial case: no xattrs
       goto UG_inode_export_xattrs_out;
    }
 
@@ -495,117 +495,117 @@ int UG_inode_export_xattrs( struct fskit_core* fs, struct UG_inode* inode, char*
       return -ENOMEM;
    }
 
-   // get each xattr 
+   // get each xattr
    xattr_ptr = xattr_list;
    for( size_t i = 0; i < num_xattrs; i++ ) {
-      
-      char* xattr_name = NULL; 
+
+      char* xattr_name = NULL;
       char* xattr_value = NULL;
       ssize_t xattr_value_len = 0;
-      
+
       xattr_name = SG_strdup_or_null( xattr_ptr );
       if( xattr_name == NULL ) {
-         
+
          rc = -ENOMEM;
          goto UG_inode_export_xattrs_fail;
       }
-      
+
       xattr_value_len = fskit_xattr_fgetxattr( fs, inode->entry, xattr_name, NULL, 0 );
       if( xattr_value_len < 0 ) {
-         
+
          rc = xattr_value_len;
          SG_safe_free( xattr_name );
          goto UG_inode_export_xattrs_fail;
       }
-      
+
       xattr_value = SG_CALLOC( char, xattr_value_len );
       if( xattr_value == NULL ) {
-         
+
          rc = -ENOMEM;
          SG_safe_free( xattr_name );
          goto UG_inode_export_xattrs_fail;
       }
-      
+
       rc = fskit_xattr_fgetxattr( fs, inode->entry, xattr_name, xattr_value, xattr_value_len );
       if( rc < 0 ) {
-         
+
          SG_safe_free( xattr_name );
          SG_safe_free( xattr_value );
          goto UG_inode_export_xattrs_fail;
       }
-      
+
       xattr_names[i] = xattr_name;
       xattr_values[i] = xattr_value;
       xattr_value_lengths[i] = xattr_value_len;
    }
-  
+
 UG_inode_export_xattrs_out:
 
    *ret_xattr_names = xattr_names;
    *ret_xattr_values = xattr_values;
    *ret_xattr_value_lengths = xattr_value_lengths;
    SG_safe_free( xattr_list );
-   
+
    return 0;
-   
+
 UG_inode_export_xattrs_fail:
 
    SG_FREE_LIST( xattr_names, free );
    SG_FREE_LIST( xattr_values, free );
    SG_safe_free( xattr_value_lengths );
    SG_safe_free( xattr_list );
-   
+
    return rc;
 }
 
 
 // calculate the xattr hash for an inode
 // return 0 on success, and fill in xattr_hash (which must be SHA256_DIGEST_LENGTH bytes or more)
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if we do not have any xattrs for this (i.e. we should only have xattrs if we're the coordintaor)
 int UG_inode_export_xattr_hash( struct fskit_core* fs, uint64_t gateway_id, struct UG_inode* inode, unsigned char* xattr_hash ) {
-   
+
    int rc = 0;
    char** xattr_names = NULL;
    char** xattr_values = NULL;
    size_t* xattr_lengths = NULL;
-   
+
    if( gateway_id != SG_manifest_get_coordinator( &inode->manifest ) ) {
 
        SG_error("BUG: %" PRIu64 " != %" PRIu64 "\n", gateway_id, SG_manifest_get_coordinator( &inode->manifest ) );
        exit(1);
        return -EINVAL;
    }
-   
+
    rc = UG_inode_export_xattrs( fs, inode, &xattr_names, &xattr_values, &xattr_lengths );
    if( rc != 0 ) {
-     
-      SG_error("UG_inode_export_xattrs(%" PRIX64 ") rc = %d\n", UG_inode_file_id( inode ), rc ); 
+
+      SG_error("UG_inode_export_xattrs(%" PRIX64 ") rc = %d\n", UG_inode_file_id( inode ), rc );
       return rc;
    }
 
    memset( xattr_hash, 0, SHA256_DIGEST_LENGTH );
    rc = ms_client_xattr_hash( xattr_hash, SG_manifest_get_volume_id( &inode->manifest ), UG_inode_file_id( inode ), inode->xattr_nonce, xattr_names, xattr_values, xattr_lengths );
-  
+
    SG_FREE_LIST( xattr_names, free );
    SG_FREE_LIST( xattr_values, free );
    SG_safe_free( xattr_lengths );
-   
+
    return rc;
 }
 
-// export an inode to an md_entry 
+// export an inode to an md_entry
 // NOTE: does *not* set the xattr hash or signature
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // NOTE: src->entry must be read-locked
 int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t parent_id ) {
-   
+
    // get type
    int type = fskit_entry_get_type( src->entry );
-   
+
    memset( dest, 0, sizeof(struct md_entry) );
-   
+
    if( type == FSKIT_ENTRY_TYPE_FILE ) {
       dest->type = MD_ENTRY_FILE;
    }
@@ -613,23 +613,23 @@ int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t paren
       dest->type = MD_ENTRY_DIR;
    }
    else {
-      // invalid 
+      // invalid
       return -EINVAL;
    }
-   
+
    char* name = SG_strdup_or_null( src->name );
    if( name == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    dest->type = type;
    dest->name = name;
    dest->file_id = fskit_entry_get_file_id( src->entry );
-   
+
    fskit_entry_get_ctime( src->entry, &dest->ctime_sec, &dest->ctime_nsec );
    fskit_entry_get_mtime( src->entry, &dest->mtime_sec, &dest->mtime_nsec );
-   
+
    if( type == FSKIT_ENTRY_TYPE_FILE ) {
       SG_manifest_get_modtime( &src->manifest, &dest->manifest_mtime_sec, &dest->manifest_mtime_nsec );
    }
@@ -637,7 +637,7 @@ int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t paren
       dest->manifest_mtime_sec = 0;
       dest->manifest_mtime_nsec = 0;
    }
-   
+
    dest->write_nonce = src->write_nonce;
    dest->xattr_nonce = src->xattr_nonce;
    dest->version = SG_manifest_get_file_version( &src->manifest );
@@ -656,9 +656,9 @@ int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t paren
    dest->xattr_hash = NULL;
    dest->ent_sig = NULL;
    dest->ent_sig_len = 0;
-  
+
    /////////////////////////////////////
-   /* 
+   /*
    char* tmp = NULL;
    int rc = md_entry_to_string( dest, &tmp );
    if( rc == 0 && tmp != NULL ) {
@@ -672,23 +672,23 @@ int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t paren
 
 // does an exported inode's type match the inode's type?
 // return 1 if so
-// return 0 if not 
+// return 0 if not
 // NOTE: dest->entry must be read-locked
 int UG_inode_export_match_type( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    int type = fskit_entry_get_type( dest->entry );
    bool valid_type = false;
-   
-   
+
+
    if( type == FSKIT_ENTRY_TYPE_FILE && src->type == MD_ENTRY_FILE ) {
-      
+
       valid_type = true;
    }
    else if( type == FSKIT_ENTRY_TYPE_DIR && src->type == MD_ENTRY_DIR ) {
-      
+
       valid_type = true;
    }
-   
+
    if( !valid_type ) {
       return 0;
    }
@@ -699,68 +699,68 @@ int UG_inode_export_match_type( struct UG_inode* dest, struct md_entry* src ) {
 
 
 // does an exported inode's size match the inode's size?
-// return 1 if so, 0 if not 
+// return 1 if so, 0 if not
 // NOTE: dest->entry must be read-locked
 int UG_inode_export_match_size( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    // size matches?
    if( fskit_entry_get_size( dest->entry ) != (unsigned)src->size ) {
-      
+
       return 0;
    }
    else {
-      
+
       return 1;
    }
 }
 
 
 // does an exported inode's version match an inode's version?
-// return 1 if so, 0 if not 
+// return 1 if so, 0 if not
 // NOTE: dest->entry must be read-locked
 int UG_inode_export_match_version( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    // version matches?
    if( UG_inode_file_version( dest ) != src->version ) {
-      
+
       return 0;
    }
    else {
-      
+
       return 1;
    }
 }
 
 
 // does an exported inode's file ID match an inode's file ID?
-// return 1 if so, 0 if not 
-// NOTE: dest->entry must be read-locked 
+// return 1 if so, 0 if not
+// NOTE: dest->entry must be read-locked
 int UG_inode_export_match_file_id( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    // file ID matches?
    if( fskit_entry_get_file_id( dest->entry ) != src->file_id ) {
-      
+
       return 0;
    }
    else {
-      
+
       return 1;
    }
 }
 
 
 // does an exported inode's volume ID match an inode's volume ID?
-// return 1 if so, 0 if not 
-// NOTE: dest->entry must be read-locked 
+// return 1 if so, 0 if not
+// NOTE: dest->entry must be read-locked
 int UG_inode_export_match_volume_id( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    // file ID matches?
    if( SG_manifest_get_volume_id( &dest->manifest ) != src->volume ) {
-      
+
       return 0;
    }
    else {
-      
+
       return 1;
    }
 }
@@ -769,107 +769,107 @@ int UG_inode_export_match_volume_id( struct UG_inode* dest, struct md_entry* src
 // does an exported inode's name match the inode's name?
 // return 1 if so, 0 if not
 // return -ENOMEM on OOM
-// NOTE: dest->entry must be read-locked 
+// NOTE: dest->entry must be read-locked
 int UG_inode_export_match_name( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    return (strcmp( dest->name, src->name ) == 0);
 }
 
 
 // import inode metadata from an md_entry
-// inode must already be initialized 
+// inode must already be initialized
 // NOTE: dest's type, file ID, version, name, and size must match src's, if dest has an associated entry.
 // The caller must make sure of this out-of-band, since changing these requires some kind of I/O or directory structure clean-up
-// return 0 on success 
+// return 0 on success
 // return -EINVAL if the types, IDs, versions, sizes, or names don't match (and dest has entry data)
 // return -EPERM if dest or src or dest->entry are NULL
 // NOTE: dest->entry must be write-locked
 int UG_inode_import( struct UG_inode* dest, struct md_entry* src ) {
-   
+
    if( src == NULL || dest == NULL ) {
-      
+
       SG_error("src == %p, dest == %p\n", src, dest );
       return -EPERM;
    }
-   
+
    if( dest->entry == NULL ) {
-      
+
       SG_error("dest->entry == %p\n", dest->entry );
       return -EPERM;
    }
-  
+
    if( !UG_inode_export_match_volume_id( dest, src ) ) {
-      
+
       SG_error("src->volume_id == %" PRIu64 ", dest->volume_id == %" PRIu64 "\n", src->volume, UG_inode_volume_id( dest ) );
       return -EINVAL;
    }
-   
+
    if( !UG_inode_export_match_file_id( dest, src ) ) {
-      
+
       SG_error("src->file_id == %" PRIX64 ", dest->file_id == %" PRIX64 "\n", src->file_id, UG_inode_file_id( dest ) );
       return -EINVAL;
    }
-   
+
    if( UG_inode_export_match_name( dest, src ) <= 0 ) {
-      
+
       SG_error("%" PRIX64 ": src->name == '%s', dest->name == '%s'\n", src->file_id, src->name, dest->name );
-      
+
       return -EINVAL;
    }
-   
+
    if( !UG_inode_export_match_size( dest, src ) ) {
-      
+
       SG_error("%" PRIX64 ": src->size == %zu, dest->size == %zu\n", src->file_id, src->size, fskit_entry_get_size( dest->entry ) );
       return -EINVAL;
    }
-   
+
    if( !UG_inode_export_match_type( dest, src ) ) {
-      
+
       SG_error("%" PRIX64 ": src->type == %d, dest->type == %d\n", src->file_id, src->type, fskit_entry_get_type( dest->entry ) );
       return -EINVAL;
    }
-   
+
    if( !UG_inode_export_match_version( dest, src ) ) {
-      
+
       SG_error("%" PRIX64 ": src->version = %" PRId64 ", dest->version = %" PRId64 "\n", src->version, src->version, UG_inode_file_version( dest ) );
       return -EINVAL;
    }
-    
+
    /////////////////////////////////////
-   
+
    char* tmp = NULL;
    int rc = md_entry_to_string( src, &tmp );
    if( rc == 0 && tmp != NULL ) {
       SG_debug("Import '%s' with:\n%s\n", src->name, tmp );
       SG_safe_free( tmp );
    }
-   
+
    /////////////////////////////////////
 
    struct timespec ts;
-   
+
    // looks good!
    ts.tv_sec = src->ctime_sec;
    ts.tv_nsec = src->ctime_nsec;
    fskit_entry_set_ctime( dest->entry, &ts );
-   
+
    ts.tv_sec = src->mtime_sec;
    ts.tv_nsec = src->mtime_nsec;
    fskit_entry_set_mtime( dest->entry, &ts );
-   
+
    SG_manifest_set_coordinator_id( &dest->manifest, src->coordinator );
    SG_manifest_set_owner_id( &dest->manifest, src->owner );
-   
+
    dest->max_read_freshness = src->max_read_freshness;
    dest->max_write_freshness = src->max_write_freshness;
-   
+
    fskit_entry_set_owner_and_group( dest->entry, src->owner, src->volume );
    fskit_entry_set_mode( dest->entry, src->mode );
-   
+
    dest->generation = src->generation;
    dest->ms_num_children = src->num_children;
    dest->ms_capacity = src->capacity;
-   
+
    if( src->xattr_hash != NULL ) {
        memcpy( dest->ms_xattr_hash, src->xattr_hash, SHA256_DIGEST_LENGTH );
    }
@@ -887,72 +887,72 @@ int UG_inode_import( struct UG_inode* dest, struct md_entry* src ) {
 // NOTE: fent will be write-locked by fskit
 // NOTE: for files, this will disable truncate (so the subsequent trunc(2) that follows a creat(2) does not incur an extra round-trip)
 int UG_inode_publish( struct SG_gateway* gateway, struct fskit_entry* fent, struct md_entry* ent_data, struct UG_inode** ret_inode_data ) {
-   
+
    int rc = 0;
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    char const* method_name = NULL;
    bool is_mkdir = (ent_data->type == MD_ENTRY_DIR);
-   
-   // inode data 
+
+   // inode data
    struct UG_inode* inode = NULL;
    struct md_entry inode_data_out;
-   
+
    memset( &inode_data_out, 0, sizeof(struct md_entry) );
-   
+
    // make the request
    if( is_mkdir ) {
-      
+
       method_name = "ms_client_mkdir";
-      rc = ms_client_mkdir( ms, &inode_data_out, ent_data );   
+      rc = ms_client_mkdir( ms, &inode_data_out, ent_data );
    }
    else {
-      
+
       method_name = "ms_client_create";
       rc = ms_client_create( ms, &inode_data_out, ent_data );
    }
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("%s rc = %d\n", method_name, rc );
-      
+
       md_entry_free( &inode_data_out );
       return rc;
    }
-   
-   // update the child with the new inode number 
+
+   // update the child with the new inode number
    fskit_entry_set_file_id( fent, inode_data_out.file_id );
    fskit_entry_set_mode( fent, inode_data_out.mode );
    fskit_entry_set_owner( fent, inode_data_out.owner );
-   
-   // success!  create the inode data 
+
+   // success!  create the inode data
    inode = UG_inode_alloc( 1 );
    if( inode == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    /////////////////////////////////////
-   
+
    char* tmp = NULL;
    rc = md_entry_to_string( &inode_data_out, &tmp );
    if( rc == 0 && tmp != NULL ) {
       SG_debug("Initialize inode '%s' with:\n%s\n", inode_data_out.name, tmp );
       SG_safe_free( tmp );
    }
-   
+
    /////////////////////////////////////
 
    rc = UG_inode_init( inode, ent_data->name, fent, ms_client_get_volume_id( ms ), SG_gateway_id( gateway ), inode_data_out.version );
    if( rc != 0 ) {
-      
+
       SG_error("UG_inode_init rc = %d\n", rc );
-      
+
       SG_safe_free( inode );
       md_entry_free( &inode_data_out );
       return rc;
    }
-   
+
    UG_inode_set_write_nonce( inode, inode_data_out.write_nonce );
    UG_inode_set_xattr_nonce( inode, inode_data_out.xattr_nonce );
    UG_inode_set_max_read_freshness( inode, inode_data_out.max_read_freshness );
@@ -964,35 +964,35 @@ int UG_inode_publish( struct SG_gateway* gateway, struct fskit_entry* fent, stru
 
    // NOTE: should be equal to file's modtime
    SG_manifest_set_modtime( UG_inode_manifest( inode ), ent_data->manifest_mtime_sec, ent_data->manifest_mtime_nsec );
-   
+
    // success!
    *ret_inode_data = inode;
    md_entry_free( &inode_data_out );
-   
+
    UG_inode_bind_fskit_entry( inode, fent );
 
    // mark as creating, so the following trunc(2) call will avoid an extra network round-trip
    UG_inode_set_creating( inode, true );
-   
+
    return 0;
 }
 
 
 // does an inode's manifest have a more recent modtime than the given one?
-// return true if so; false if not 
+// return true if so; false if not
 bool UG_inode_manifest_is_newer_than( struct SG_manifest* manifest, int64_t mtime_sec, int32_t mtime_nsec ) {
-   
+
    struct timespec old_manifest_ts;
    struct timespec new_manifest_ts;
-   
+
    new_manifest_ts.tv_sec = mtime_sec;
    new_manifest_ts.tv_nsec = mtime_nsec;
-   
+
    old_manifest_ts.tv_sec = SG_manifest_get_modtime_sec( manifest );
    old_manifest_ts.tv_nsec = SG_manifest_get_modtime_nsec( manifest );
-   
+
    bool newer = (md_timespec_diff( &new_manifest_ts, &old_manifest_ts ) > 0);
-   
+
    return newer;
 }
 
@@ -1002,53 +1002,53 @@ bool UG_inode_manifest_is_newer_than( struct SG_manifest* manifest, int64_t mtim
 // remove now-invalid garbage block data.
 // return 0 on success, and populate the inode's manifest with the given manifest's block data
 // return -ENOMEM on OOM
-// NOTE: inode->entry must be write-locked 
+// NOTE: inode->entry must be write-locked
 // NOTE: this method is idempotent, and will partially-succeed if it returns -ENOMEM.  Callers are encouraged to try and retry until it succeeds
 // NOTE: this method is a commutative and associative on manifests--given manifests A, B, and C, doesn't matter what order they get merged
 // NOTE: (i.e. merge( merge(A, B), C ) == merge( A, merge( B, C ) ) and merge( A, B ) == merge( B, A ))
 // NOTE: does *NOT* merge size, does *NOT* merge modtime, and does *NOT* attempt to truncate
 int UG_inode_manifest_merge_blocks( struct SG_gateway* gateway, struct UG_inode* inode, struct SG_manifest* new_manifest ) {
-   
+
    int rc = 0;
    struct md_syndicate_cache* cache = SG_gateway_cache( gateway );
-   
+
    bool replace;        // set to true if we will replace blocks in the manifest; false if not (i.e. depends on whether the "new_manifest" is actually newer)
-   
+
    // i.e. if our manifest is newer than the "new" manifest, then don't replace blocks on conflict
    replace = !UG_inode_manifest_is_newer_than( UG_inode_manifest( inode ), SG_manifest_get_modtime_sec( new_manifest ), SG_manifest_get_modtime_nsec( new_manifest ) );
-   
+
    // add all blocks in new_manifest
    for( SG_manifest_block_iterator itr = SG_manifest_block_iterator_begin( new_manifest ); itr != SG_manifest_block_iterator_end( new_manifest ); itr++ ) {
-      
+
       uint64_t block_id = SG_manifest_block_iterator_id( itr );
       struct SG_manifest_block* new_block = SG_manifest_block_iterator_block( itr );
-      
+
       UG_dirty_block_map_t::iterator dirty_block_itr;
       struct UG_dirty_block* dirty_block = NULL;
-      
+
       struct SG_manifest_block* replaced_block = NULL;
-      
+
       struct SG_manifest_block* existing_block = SG_manifest_block_lookup( UG_inode_manifest( inode ), block_id );
       int64_t existing_block_version = 0;
-         
+
       if( existing_block != NULL ) {
-            
+
          if( SG_manifest_block_version( existing_block ) == SG_manifest_block_version( new_block ) ) {
-            
+
             // already merged, or no change
             continue;
          }
-         
-         // if the local block is dirty, keep the local block 
+
+         // if the local block is dirty, keep the local block
          if( SG_manifest_block_is_dirty( existing_block ) ) {
-            
+
             continue;
          }
-         
-         // preserve existing block data that will get overwritten 
+
+         // preserve existing block data that will get overwritten
          existing_block_version = SG_manifest_block_version( existing_block );
       }
-      
+
       // merge into current manifest, replacing the old one *if* the new_manifest is actually newer (makes this method commutative, associative)
       // that is, only overwrite a block if the block is not dirty, and if the new_manifest has a newer modification time (this in turn is guaranteed
       // to be monotonically increasing since there is at most one coordinator).
@@ -1062,69 +1062,69 @@ int UG_inode_manifest_merge_blocks( struct SG_gateway* gateway, struct UG_inode*
       }
 
       if( rc != 0 && rc != -EEXIST ) {
-          
+
          break;
       }
-      
+
       // clear cached block (idempotent)
       if( existing_block != NULL ) {
           md_cache_evict_block( cache, UG_inode_file_id( inode ), UG_inode_file_version( inode ), block_id, existing_block_version, 0 );
       }
-      
+
       // clear dirty block (idempotent)
       dirty_block_itr = UG_inode_dirty_blocks( inode )->find( block_id );
       if( dirty_block_itr != UG_inode_dirty_blocks( inode )->end() ) {
-         
+
          dirty_block = &dirty_block_itr->second;
          UG_dirty_block_evict_and_free( cache, inode, dirty_block );
-         
+
          // clear invalidated garbage, if there is any (idempotent)
          replaced_block = SG_manifest_block_lookup( UG_inode_replaced_blocks( inode ), block_id );
          if( replaced_block != NULL ) {
-            
+
             SG_manifest_delete_block( UG_inode_replaced_blocks( inode ), block_id );
          }
       }
    }
-   
+
    return rc;
 }
 
 
 // remove dirty blocks from the inode, and put them into *modified
 // return 0 on success, and fill in *modified. the inode will no longer have modified dirty blocks
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // NOTE: inode->entry must be write-locked
 int UG_inode_dirty_blocks_extract( struct UG_inode* inode, UG_dirty_block_map_t* modified ) {
-   
+
    for( UG_dirty_block_map_t::iterator itr = UG_inode_dirty_blocks( inode )->begin(); itr != UG_inode_dirty_blocks( inode )->end(); itr++ ) {
-      
+
       // dirty?
       if( !UG_dirty_block_dirty( &itr->second ) ) {
-         
+
          continue;
       }
-      
+
       try {
-         
+
          (*modified)[ itr->first ] = itr->second;
       }
       catch( bad_alloc& ba ) {
          return -ENOMEM;
       }
    }
-   
-   // and remove from the inode 
+
+   // and remove from the inode
    for( UG_dirty_block_map_t::iterator itr = modified->begin(); itr != modified->end(); itr++ ) {
-     
+
       UG_dirty_block_map_t::iterator dirty_itr = UG_inode_dirty_blocks( inode )->find( itr->first );
       if( dirty_itr != UG_inode_dirty_blocks( inode )->end() ) {
          UG_inode_dirty_blocks( inode )->erase( dirty_itr );
-      } 
+      }
    }
 
    SG_debug("Extracted %zu dirty blocks (%zu remaining)\n", modified->size(), UG_inode_dirty_blocks( inode )->size() );
-   
+
    return 0;
 }
 
@@ -1132,31 +1132,31 @@ int UG_inode_dirty_blocks_extract( struct UG_inode* inode, UG_dirty_block_map_t*
 // return extracted dirty blocks to an inode.  clear them out of *extracted as we do so.
 // You should call this in the same critical section as UG_inode_dirty_blocks_extract()
 // return 0 on success
-// return -ENOMEM on OOM 
-// NOTE: inode->entry must be write-locked; locked in the same context as the _extract_ method was called 
+// return -ENOMEM on OOM
+// NOTE: inode->entry must be write-locked; locked in the same context as the _extract_ method was called
 // NOTE: this method is idempotent.  call it multiple times if it fails
 int UG_inode_dirty_blocks_return( struct UG_inode* inode, UG_dirty_block_map_t* extracted ) {
-   
+
    int rc = 0;
-   
+
    for( UG_dirty_block_map_t::iterator itr = extracted->begin(); itr != extracted->end(); ) {
-      
-      try { 
-         
+
+      try {
+
          (*UG_inode_dirty_blocks( inode ))[ itr->first ] = itr->second;
       }
       catch( bad_alloc& ba ) {
-         
+
          rc = -ENOMEM;
          break;
       }
-      
+
       UG_dirty_block_map_t::iterator old_itr = itr;
       itr++;
-      
+
       extracted->erase( old_itr );
    }
-   
+
    return rc;
 }
 
@@ -1166,36 +1166,36 @@ int UG_inode_dirty_blocks_return( struct UG_inode* inode, UG_dirty_block_map_t* 
 // succeeds if there is already a block cached, but with the same version.
 // does not affect the inode's manifest or replaced_block sets.
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if the block is dirty
 // return -EEXIST if the block would replace a different block, and replace was false
 // NOTE: inode->entry must be write-locked
 // NOTE: inode takes ownership of dirty_block's contents.
 int UG_inode_dirty_block_put( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block, bool replace ) {
-   
+
    struct md_syndicate_cache* cache = SG_gateway_cache( gateway );
    struct UG_dirty_block* old_dirty_block = NULL;
    UG_dirty_block_map_t::iterator old_dirty_block_itr;
-   
+
    // already cached?
    old_dirty_block_itr = UG_inode_dirty_blocks( inode )->find( UG_dirty_block_id( dirty_block ) );
    if( old_dirty_block_itr != UG_inode_dirty_blocks( inode )->end() ) {
-      
+
       old_dirty_block = &old_dirty_block_itr->second;
-      
+
       // there's a block here. is it the same one?
       if( UG_dirty_block_version( dirty_block ) == UG_dirty_block_version( old_dirty_block ) ) {
-         
+
          return 0;
       }
       else if( !replace ) {
-         
+
          return -EEXIST;
       }
       else {
 
          // evict old dirty block
-         SG_debug("Replace dirty block %" PRIu64 ".%" PRId64 " with %" PRIu64 ".%" PRId64 "\n", 
+         SG_debug("Replace dirty block %" PRIu64 ".%" PRId64 " with %" PRIu64 ".%" PRId64 "\n",
                UG_dirty_block_id( old_dirty_block ), UG_dirty_block_version( old_dirty_block ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ));
 
          UG_dirty_block_evict_and_free( cache, inode, old_dirty_block );
@@ -1211,46 +1211,46 @@ int UG_inode_dirty_block_put( struct SG_gateway* gateway, struct UG_inode* inode
          return 0;
       }
    }
-   
+
    // not present.  put in place.
    try {
-      
+
       SG_debug("Insert dirty block %" PRIu64 ".%" PRId64 "\n",
             UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ));
 
       (*UG_inode_dirty_blocks( inode ))[ UG_dirty_block_id( dirty_block ) ] = *dirty_block;
    }
    catch( bad_alloc& ba ) {
-      
+
       return -ENOMEM;
    }
-   
+
    return 0;
 }
 
 
 // preserve an inode's old manifest timestamp on modification,
 // so we can garbage-collect the old manifest when we fsync() the inode.
-// always succeeds 
+// always succeeds
 // NOTE: inode->entry must be write-locked
 static int UG_inode_preserve_old_manifest_timestamp( struct UG_inode* inode ) {
 
    int64_t manifest_mtime_sec = 0;
    int32_t manifest_mtime_nsec = 0;
    if( SG_manifest_get_modtime_sec( &inode->replaced_blocks ) == 0 && SG_manifest_get_modtime_nsec( &inode->replaced_blocks ) == 0 ) {
-      
+
       manifest_mtime_sec = SG_manifest_get_modtime_sec( &inode->manifest );
       manifest_mtime_nsec = SG_manifest_get_modtime_nsec( &inode->manifest );
 
       SG_manifest_set_modtime( &inode->replaced_blocks, manifest_mtime_sec, manifest_mtime_nsec );
-   
-      SG_debug("SET old manifest timestamp for %" PRIX64 " is %" PRId64 ".%d\n", UG_inode_file_id( inode ), 
+
+      SG_debug("SET old manifest timestamp for %" PRIX64 " is %" PRId64 ".%d\n", UG_inode_file_id( inode ),
          SG_manifest_get_modtime_sec( &inode->replaced_blocks ), SG_manifest_get_modtime_nsec( &inode->replaced_blocks ) );
 
    }
    else {
-     
-      SG_debug("old manifest timestamp for %" PRIX64 " is %" PRId64 ".%d\n", UG_inode_file_id( inode ), 
+
+      SG_debug("old manifest timestamp for %" PRIX64 " is %" PRId64 ".%d\n", UG_inode_file_id( inode ),
          SG_manifest_get_modtime_sec( &inode->replaced_blocks ), SG_manifest_get_modtime_nsec( &inode->replaced_blocks ) );
 
    }
@@ -1263,95 +1263,95 @@ static int UG_inode_preserve_old_manifest_timestamp( struct UG_inode* inode ) {
 // Remember old block information for blocks that must be garbage-collected.
 // return 0 on success.  The inode takes ownership of dirty_block.
 // return 0 if the block is already present in the manifest (in which case dirty_block is freed)
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if dirty_block is not dirty or not flushed
 // NOTE: inode->entry must be write-locked!
 // NOTE: inode takes ownership of dirty_block's contents
 // NOTE: the block must have been flushed to disk.
 int UG_inode_dirty_block_update_manifest( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block ) {
-   
+
    int rc = 0;
-   
+
    SG_debug("update manifest %" PRId64 ".%d for %" PRIX64 "[%" PRIu64 ".%" PRId64 "] (%p)\n",
             SG_manifest_get_modtime_sec( UG_inode_manifest( inode ) ), SG_manifest_get_modtime_nsec( UG_inode_manifest( inode ) ),
             UG_inode_file_id( inode ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ), dirty_block );
 
-   // sanity check: must be flushed to disk 
+   // sanity check: must be flushed to disk
    if( !UG_dirty_block_is_flushed( dirty_block ) ) {
 
       SG_error("BUG: block [%" PRIu64 ".%" PRId64 "] is not flushed\n", UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ) );
       exit(1);
       return -EINVAL;
    }
-   
+
    // sanity check: must be dirty
    if( !UG_dirty_block_dirty( dirty_block ) ) {
-     
+
       SG_error("BUG: block [%" PRIu64 ".%" PRId64 "] is not dirty\n", UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ) );
-      exit(1); 
+      exit(1);
       return -EINVAL;
    }
-   
+
    struct SG_manifest_block old_block_info;
-   
+
    // what blocks are being replaced?
    struct SG_manifest_block* old_block_info_ref = SG_manifest_block_lookup( UG_inode_manifest( inode ), UG_dirty_block_id( dirty_block ) );
    struct SG_manifest_block* old_replaced_block_info = SG_manifest_block_lookup( UG_inode_replaced_blocks( inode ), UG_dirty_block_id( dirty_block ) );
-  
-   // store a copy, so we can put it back on failure 
+
+   // store a copy, so we can put it back on failure
    if( old_block_info_ref != NULL ) {
-      
+
       rc = SG_manifest_block_dup( &old_block_info, old_block_info_ref );
       if( rc != 0 ) {
-         
-         // OOM 
+
+         // OOM
          return rc;
       }
    }
-   
+
    // update the manifest with the new dirty block info
    rc = SG_manifest_put_block( UG_inode_manifest( inode ), UG_dirty_block_info( dirty_block ), true );
    if( rc != 0 ) {
-      
-      SG_error("SG_manifest_put_block( %" PRIX64 ".%" PRIu64" [%" PRId64 ".%" PRIu64 "] ) rc = %d\n", 
+
+      SG_error("SG_manifest_put_block( %" PRIX64 ".%" PRIu64" [%" PRId64 ".%" PRIu64 "] ) rc = %d\n",
                UG_inode_file_id( inode ), UG_inode_file_version( inode ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ), rc );
-      
+
       if( old_block_info_ref != NULL ) {
-         
+
          SG_manifest_block_free( &old_block_info );
       }
-      
+
       return rc;
    }
-   
+
    if( old_block_info_ref != NULL ) {
-      
+
       if( old_replaced_block_info == NULL ) {
-         
+
          // we replaced a block in the manifest, so we'll need to garbage-collect the old version.
          // we can forget about the previous old version (generated on a previous write), since it is
          // not replicated (we just need to evict any local state it had).
          rc = SG_manifest_put_block_nocopy( UG_inode_replaced_blocks( inode ), &old_block_info, true );
          if( rc != 0 ) {
-            
-            SG_error("SG_manifest_put_block( %" PRIX64 ".%" PRIu64" [%" PRId64 ".%" PRIu64 "] ) rc = %d\n", 
+
+            SG_error("SG_manifest_put_block( %" PRIX64 ".%" PRIu64" [%" PRId64 ".%" PRIu64 "] ) rc = %d\n",
                      UG_inode_file_id( inode ), UG_inode_file_version( inode ), old_block_info.block_id, old_block_info.block_version, rc );
-            
-            // put the old block data back 
-            // NOTE: guaranteed to succeed, since we're replacing without copying or allocating 
+
+            // put the old block data back
+            // NOTE: guaranteed to succeed, since we're replacing without copying or allocating
             SG_manifest_put_block_nocopy( UG_inode_manifest( inode ), &old_block_info, true );
-            
+
             goto UG_inode_block_update_manifest_out;
          }
       }
    }
-   
+
    // this block is dirty--keep it in the face of future manifest refreshes until we replicate (via fsync())
    SG_manifest_set_block_dirty( UG_inode_manifest( inode ), UG_dirty_block_id( dirty_block ), true );
    UG_inode_preserve_old_manifest_timestamp( inode );
-   
+
 UG_inode_block_update_manifest_out:
-   
+
    return rc;
 }
 
@@ -1363,29 +1363,29 @@ UG_inode_block_update_manifest_out:
 // remember old block information for blocks that must be garbage-collected.
 // return 0 on success.  The inode takes ownership of dirty_block.
 // return 0 if the block is already present in the manifest (in which case dirty_block is freed)
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if dirty_block is not dirty or not flushed
 // NOTE: inode->entry must be write-locked!
 // NOTE: inode takes ownership of dirty_block's contents
 int UG_inode_dirty_block_commit( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block ) {
-   
+
    int rc = 0;
-   
+
    SG_debug("commit %" PRIX64 "[%" PRIu64 ".%" PRId64 "] (%p)\n", UG_inode_file_id( inode ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ), dirty_block );
 
-   // sanity check: must be flushed to disk 
+   // sanity check: must be flushed to disk
    if( !UG_dirty_block_is_flushed( dirty_block ) ) {
 
       SG_error("BUG: block [%" PRIu64 ".%" PRId64 "] is not flushed\n", UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ) );
       exit(1);
       return -EINVAL;
    }
-   
+
    // sanity check: must be dirty
    if( !UG_dirty_block_dirty( dirty_block ) ) {
-     
+
       SG_error("BUG: block [%" PRIu64 ".%" PRId64 "] is not dirty\n", UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ) );
-      exit(1); 
+      exit(1);
       return -EINVAL;
    }
 
@@ -1393,7 +1393,7 @@ int UG_inode_dirty_block_commit( struct SG_gateway* gateway, struct UG_inode* in
    rc = UG_inode_dirty_block_update_manifest( gateway, inode, dirty_block );
    if( rc != 0 ) {
 
-      SG_error("UG_inode_dirty_block_update_manifest( %" PRIX64 "[%" PRIu64 ".%" PRId64 "] ) rc = %d\n", 
+      SG_error("UG_inode_dirty_block_update_manifest( %" PRIX64 "[%" PRIu64 ".%" PRId64 "] ) rc = %d\n",
             UG_inode_file_id( inode ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ), rc );
 
       return rc;
@@ -1402,8 +1402,8 @@ int UG_inode_dirty_block_commit( struct SG_gateway* gateway, struct UG_inode* in
    // put new dirty block
    rc = UG_inode_dirty_block_put( gateway, inode, dirty_block, true );
    if( rc != 0 ) {
-      
-      SG_error("FATAL: failed to put new dirty block %" PRIX64 "[%" PRIu64 ".%" PRId64 "], rc = %d\n", 
+
+      SG_error("FATAL: failed to put new dirty block %" PRIX64 "[%" PRIu64 ".%" PRId64 "], rc = %d\n",
             UG_inode_file_id( inode ), UG_dirty_block_id( dirty_block ), UG_dirty_block_version( dirty_block ), rc );
 
       exit(1);
@@ -1413,18 +1413,18 @@ int UG_inode_dirty_block_commit( struct SG_gateway* gateway, struct UG_inode* in
 }
 
 
-// remember to evict a non-dirty block when we close this descriptor 
+// remember to evict a non-dirty block when we close this descriptor
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int UG_file_handle_evict_add_hint( struct UG_file_handle* fh, uint64_t block_id, int64_t block_version ) {
-   
+
    try {
       (*fh->evicts)[ block_id ] = block_version;
    }
    catch( bad_alloc& ba ) {
       return -ENOMEM;
    }
-   
+
    return 0;
 }
 
@@ -1433,91 +1433,91 @@ int UG_file_handle_evict_add_hint( struct UG_file_handle* fh, uint64_t block_id,
 // return 0 on success
 // NOTE: fh->inode_ref->entry must be write-locked
 int UG_file_handle_evict_blocks( struct UG_file_handle* fh ) {
-   
+
    for( UG_inode_block_eviction_map_t::iterator itr = fh->evicts->begin(); itr != fh->evicts->end(); itr++ ) {
-      
+
       UG_dirty_block_map_t::iterator block_itr = fh->inode_ref->dirty_blocks->find( itr->first );
       if( block_itr != fh->inode_ref->dirty_blocks->end() ) {
-         
+
          struct UG_dirty_block* dirty_block = &block_itr->second;
-         
-         // clear, if the version matches and it's not dirty 
+
+         // clear, if the version matches and it's not dirty
          if( UG_dirty_block_version( dirty_block ) == itr->second && !UG_dirty_block_dirty( dirty_block ) ) {
-            
-            // evict 
+
+            // evict
             fh->inode_ref->dirty_blocks->erase( block_itr );
-            
+
             UG_dirty_block_free( dirty_block );
          }
       }
    }
-   
+
    fh->evicts->clear();
-   
+
    return 0;
 }
 
 
-// replace the manifest of an inode 
+// replace the manifest of an inode
 // free the old one.
 // always succeeds
-// NOTE: inode->entry must be write-locked 
+// NOTE: inode->entry must be write-locked
 int UG_inode_manifest_replace( struct UG_inode* inode, struct SG_manifest* manifest ) {
-   
+
    struct SG_manifest old_manifest;
-   
+
    old_manifest = inode->manifest;
    inode->manifest = *manifest;
-   
+
    SG_manifest_free( &old_manifest );
-   
+
    return 0;
 }
 
 
 // find all blocks in the inode that would be removed by a truncation
-// return 0 on success, and populate *removed 
-// return -ENOMEM on OOM 
+// return 0 on success, and populate *removed
+// return -ENOMEM on OOM
 // NOTE: inode->entry must be at least read-locked.
 int UG_inode_truncate_find_removed( struct SG_gateway* gateway, struct UG_inode* inode, off_t new_size, struct SG_manifest* removed ) {
-   
+
    int rc = 0;
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
-   
+
    uint64_t drop_block_id = (new_size / block_size);
    if( new_size % block_size != 0 ) {
       drop_block_id ++;
    }
-   
+
    uint64_t max_block_id = SG_manifest_get_block_range( UG_inode_manifest( inode ) );
 
-   // do nothing if we're expanding 
+   // do nothing if we're expanding
    if( UG_inode_size( inode ) <= (uint64_t)new_size ) {
       return 0;
    }
 
    // copy over blocks to removed
    for( uint64_t dead_block_id = drop_block_id; dead_block_id <= max_block_id; dead_block_id++ ) {
-      
+
       struct SG_manifest_block* block_info = SG_manifest_block_lookup( UG_inode_manifest( inode ), dead_block_id );
       if( block_info == NULL ) {
-         
-         // write hole 
+
+         // write hole
          continue;
       }
-      
+
       if( removed != NULL ) {
-         
+
          rc = SG_manifest_put_block( removed, block_info, true );
          if( rc != 0 ) {
-            
+
             // OOM
             return -ENOMEM;
          }
       }
    }
-   
+
    return 0;
 }
 
@@ -1530,62 +1530,62 @@ int UG_inode_truncate_find_removed( struct SG_gateway* gateway, struct UG_inode*
 // NOTE: if this method fails with -ENOMEM, and *removed is not NULL, the caller should free up *removed
 // NOTE: if new_version is 0, the version will *not* be changed
 int UG_inode_truncate( struct SG_gateway* gateway, struct UG_inode* inode, off_t new_size, int64_t new_version, int64_t write_nonce, struct timespec* new_manifest_timestamp ) {
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
-   
+
    uint64_t drop_block_id = (new_size / block_size);
    if( new_size % block_size != 0 ) {
       drop_block_id ++;
    }
-   
+
    uint64_t max_block_id = SG_manifest_get_block_range( UG_inode_manifest( inode ) );
    int64_t old_version = UG_inode_file_version( inode );
    struct md_syndicate_cache* cache = SG_gateway_cache( gateway );
-   
+
    // go through the manifest and drop locally-cached blocks
    for( uint64_t dead_block_id = drop_block_id; dead_block_id <= max_block_id; dead_block_id++ ) {
-      
+
       struct SG_manifest_block* block_info = SG_manifest_block_lookup( UG_inode_manifest( inode ), dead_block_id );
       if( block_info == NULL ) {
-         
-         // write hole 
+
+         // write hole
          continue;
       }
-      
+
       // clear dirty block
       UG_dirty_block_map_t::iterator dirty_block_itr = UG_inode_dirty_blocks( inode )->find( drop_block_id );
       if( dirty_block_itr != UG_inode_dirty_blocks( inode )->end() ) {
-         
+
          struct UG_dirty_block* dirty_block = &dirty_block_itr->second;
-         
+
          UG_dirty_block_evict_and_free( cache, inode, dirty_block );
          UG_inode_dirty_blocks( inode )->erase( dirty_block_itr );
       }
-      
-      // clear cached block 
+
+      // clear cached block
       md_cache_evict_block( cache, UG_inode_file_id( inode ), UG_inode_file_version( inode ), dead_block_id, SG_manifest_block_version( block_info ), 0 );
    }
-   
+
    if( new_version != 0 ) {
-         
-      // next version 
+
+      // next version
       SG_manifest_set_file_version( UG_inode_manifest( inode ), new_version );
-      
-      // reversion only cached data 
+
+      // reversion only cached data
       md_cache_reversion_file( cache, UG_inode_file_id( inode ), old_version, new_version, 0 );
    }
-  
-   // drop extra manifest blocks 
+
+   // drop extra manifest blocks
    SG_manifest_truncate( UG_inode_manifest( inode ), (new_size / block_size) );
-   
-   // set new size and modtime 
+
+   // set new size and modtime
    SG_manifest_set_size( UG_inode_manifest( inode ), new_size );
 
    if( new_manifest_timestamp != NULL ) {
        SG_manifest_set_modtime( UG_inode_manifest( inode ), new_manifest_timestamp->tv_sec, new_manifest_timestamp->tv_nsec );
    }
-   
+
    if( write_nonce != 0 ) {
        UG_inode_set_write_nonce( inode, write_nonce );
    }
@@ -1593,40 +1593,40 @@ int UG_inode_truncate( struct SG_gateway* gateway, struct UG_inode* inode, off_t
    return 0;
 }
 
-// resolve a path to an inode and it's parent's information 
-// return a pointer to the locked fskit_entry on success, and set *parent_id 
+// resolve a path to an inode and it's parent's information
+// return a pointer to the locked fskit_entry on success, and set *parent_id
 // return NULL on error, and set *rc to non-zero
 static struct fskit_entry* UG_inode_resolve_path_and_parent( struct fskit_core* fs, char const* fs_path, bool writelock, int* rc, uint64_t* parent_id ) {
-   
+
    struct resolve_parent {
-      
+
       uint64_t parent_id;
-      
+
       uint64_t file_id;
-      
+
       // callback to fskit_entry_resolve_path_cls to remember the parent's name and ID
-      // return 0 on success 
+      // return 0 on success
       // return -ENOMEM on OOM
       static int remember_parent( struct fskit_entry* cur, void* cls ) {
-         
+
          struct resolve_parent* rp = (struct resolve_parent*)cls;
-         
+
           rp->parent_id = rp->file_id;
-          
+
           rp->file_id = fskit_entry_get_file_id( cur );
-          
+
           return 0;
       }
    };
-   
+
    struct resolve_parent rp;
-   
+
    struct fskit_entry* fent = fskit_entry_resolve_path_cls( fs, fs_path, 0, 0, writelock, rc, resolve_parent::remember_parent, &rp );
    if( fent == NULL ) {
-      
+
       return NULL;
    }
-   
+
    *parent_id = rp.parent_id;
    return fent;
 }
@@ -1634,36 +1634,36 @@ static struct fskit_entry* UG_inode_resolve_path_and_parent( struct fskit_core* 
 
 // export an fskit_entry inode from the filesystem
 // return 0 on success, and fill in inode_data and *renaming from the inode
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int UG_inode_export_fs( struct fskit_core* fs, char const* fs_path, struct md_entry* inode_data ) {
-   
+
    int rc = 0;
    struct fskit_entry* fent = NULL;
    struct UG_inode* inode = NULL;
-   
+
    uint64_t parent_id = 0;
-   
+
    fent = UG_inode_resolve_path_and_parent( fs, fs_path, false, &rc, &parent_id );
    if( fent == NULL ) {
-      
+
       return rc;
    }
-   
+
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    rc = UG_inode_export( inode_data, inode, parent_id );
-   
+
    fskit_entry_unlock( fent );
-   
+
    return rc;
 }
 
 
 // push a sync context to the sync queue
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int UG_inode_sync_queue_push( struct UG_inode* inode, struct UG_sync_context* sync_context ) {
-   
+
    try {
       inode->sync_queue->push( sync_context );
       return 0;
@@ -1673,24 +1673,24 @@ int UG_inode_sync_queue_push( struct UG_inode* inode, struct UG_sync_context* sy
    }
 }
 
-// pop a sync context from the sync queue and return it 
-// return NULL if empty 
+// pop a sync context from the sync queue and return it
+// return NULL if empty
 struct UG_sync_context* UG_inode_sync_queue_pop( struct UG_inode* inode ) {
- 
+
    struct UG_sync_context* ret = NULL;
-   
+
    if( inode->sync_queue->size() > 0 ) {
       ret = inode->sync_queue->front();
       inode->sync_queue->pop();
    }
-   
+
    return ret;
 }
 
-// clear the list of replaced blocks; e.g. on successful replication 
+// clear the list of replaced blocks; e.g. on successful replication
 // always succeeds
 int UG_inode_clear_replaced_blocks( struct UG_inode* inode ) {
-   
+
    SG_manifest_clear( &inode->replaced_blocks );
    SG_manifest_set_modtime( &inode->replaced_blocks, 0, 0 );
    return 0;
@@ -1766,7 +1766,7 @@ struct timespec UG_inode_old_manifest_modtime( struct UG_inode* inode ) {
    ts.tv_nsec = SG_manifest_get_modtime_nsec( &inode->replaced_blocks );
    return ts;
 }
-  
+
 struct fskit_entry* UG_inode_fskit_entry( struct UG_inode* inode ) {
    return inode->entry;
 }
@@ -1813,12 +1813,12 @@ int64_t UG_inode_ms_num_children( struct UG_inode* inode ) {
 int64_t UG_inode_ms_capacity( struct UG_inode* inode ) {
    return inode->ms_capacity;
 }
-   
-uint32_t UG_inode_max_read_freshness( struct UG_inode* inode ) {
+
+int32_t UG_inode_max_read_freshness( struct UG_inode* inode ) {
    return inode->max_read_freshness;
 }
-   
-uint32_t UG_inode_max_write_freshness( struct UG_inode* inode ) {
+
+int32_t UG_inode_max_write_freshness( struct UG_inode* inode ) {
    return inode->max_write_freshness;
 }
 
@@ -1829,7 +1829,7 @@ int64_t UG_inode_generation( struct UG_inode* inode ) {
 struct timespec UG_inode_refresh_time( struct UG_inode* inode ) {
    return inode->refresh_time;
 }
-   
+
 struct timespec UG_inode_manifest_refresh_time( struct UG_inode* inode ) {
    return inode->manifest_refresh_time;
 }
@@ -1842,7 +1842,7 @@ size_t UG_inode_sync_queue_len( struct UG_inode* inode ) {
    return inode->sync_queue->size();
 }
 
-// setters 
+// setters
 void UG_inode_set_file_version( struct UG_inode* inode, int64_t version ) {
    SG_manifest_set_file_version( &inode->manifest, version );
 }
@@ -1875,7 +1875,7 @@ void UG_inode_set_write_refresh_time( struct UG_inode* inode, struct timespec* t
 }
 
 void UG_inode_set_write_refresh_time_now( struct UG_inode* inode ) {
-   
+
    struct timespec now;
    clock_gettime( CLOCK_REALTIME, &now );
    UG_inode_set_write_refresh_time( inode, &now );
@@ -1886,7 +1886,7 @@ void UG_inode_set_manifest_refresh_time( struct UG_inode* inode, struct timespec
 }
 
 void UG_inode_set_manifest_refresh_time_now( struct UG_inode* inode ) {
-   
+
    struct timespec now;
    clock_gettime( CLOCK_REALTIME, &now );
    UG_inode_set_manifest_refresh_time( inode, &now );
@@ -1899,7 +1899,7 @@ void UG_inode_set_children_refresh_time( struct UG_inode* inode, struct timespec
 }
 
 void UG_inode_set_children_refresh_time_now( struct UG_inode* inode ) {
-   
+
    struct timespec now;
    clock_gettime( CLOCK_REALTIME, &now );
    UG_inode_set_children_refresh_time( inode, &now );
@@ -1909,11 +1909,11 @@ void UG_inode_set_old_manifest_modtime( struct UG_inode* inode, struct timespec*
    SG_manifest_set_modtime( &inode->replaced_blocks, ts->tv_sec, ts->tv_nsec );
 }
 
-void UG_inode_set_max_read_freshness( struct UG_inode* inode, uint32_t rf ) {
+void UG_inode_set_max_read_freshness( struct UG_inode* inode, int32_t rf ) {
    inode->max_read_freshness = rf;
 }
 
-void UG_inode_set_max_write_freshness( struct UG_inode* inode, uint32_t wf ) {
+void UG_inode_set_max_write_freshness( struct UG_inode* inode, int32_t wf ) {
    inode->max_write_freshness = wf;
 }
 
@@ -1955,8 +1955,8 @@ void UG_inode_set_size( struct UG_inode* inode, uint64_t new_size ) {
    SG_manifest_set_size( &inode->manifest, new_size );
 }
 
-// attach an fskit_entry to an inode, and the inode to the fskit_entry 
-// ent must be write-locked 
+// attach an fskit_entry to an inode, and the inode to the fskit_entry
+// ent must be write-locked
 void UG_inode_bind_fskit_entry( struct UG_inode* inode, struct fskit_entry* ent ) {
    UG_inode_set_fskit_entry( inode, ent );
    fskit_entry_set_user_data( ent, inode );
@@ -1964,7 +1964,7 @@ void UG_inode_bind_fskit_entry( struct UG_inode* inode, struct fskit_entry* ent 
 
 
 // preserve the old manifest timestamp: if it's not set, then copy it from the current manifest
-// NOTE: requires exclusive access to inode 
+// NOTE: requires exclusive access to inode
 void UG_inode_preserve_old_manifest_modtime( struct UG_inode* inode ) {
 
    if( SG_manifest_get_modtime_sec( &inode->replaced_blocks ) == 0 && SG_manifest_get_modtime_nsec( &inode->replaced_blocks ) == 0 ) {
@@ -1978,4 +1978,3 @@ void UG_inode_preserve_old_manifest_modtime( struct UG_inode* inode ) {
       UG_inode_set_old_manifest_modtime( inode, &ts );
    }
 }
-

--- a/libsyndicate-ug/inode.h
+++ b/libsyndicate-ug/inode.h
@@ -33,27 +33,27 @@ struct UG_sync_context;
 // queue for threads waiting to synchronize blocks
 typedef queue< struct UG_sync_context* > UG_inode_fsync_queue_t;
 
-// map block IDs to their versions, so we know which block to evict on close 
+// map block IDs to their versions, so we know which block to evict on close
 typedef map< uint64_t, int64_t > UG_inode_block_eviction_map_t;
 
 // UG-specific inode information, for fskit
 struct UG_inode;
 
-// UG-specific file handle information, for fskit 
+// UG-specific file handle information, for fskit
 struct UG_file_handle {
-   
+
    int flags;                           // open flags
-   
+
    struct UG_inode* inode_ref;          // reference to the parent inode (i.e. so we can release dirty blocks)
-   
-   struct fskit_file_handle* handle_ref;        // refernece to the parent fskit file handle 
-   
-   UG_inode_block_eviction_map_t* evicts;       // non-dirty blocks to evict on close 
+
+   struct fskit_file_handle* handle_ref;        // refernece to the parent fskit file handle
+
+   UG_inode_block_eviction_map_t* evicts;       // non-dirty blocks to evict on close
 };
 
 
 extern "C" {
-   
+
 // initialization
 struct UG_inode* UG_inode_alloc( int count );
 int UG_inode_init( struct UG_inode* inode, char const* name, struct fskit_entry* entry, uint64_t volume_id, uint64_t coordinator_id, int64_t file_version );
@@ -61,16 +61,16 @@ int UG_inode_init_from_export( struct UG_inode* inode, struct md_entry* inode_da
 int UG_inode_fskit_entry_init( struct fskit_core* fs, struct fskit_entry* fent, struct fskit_entry* parent, struct md_entry* inode_data );
 int UG_inode_fskit_common_init( struct fskit_entry* fent, struct md_entry* inode_data );
 
-// free 
+// free
 int UG_inode_free( struct UG_inode* inode );
 
-// set up a file handle 
+// set up a file handle
 int UG_file_handle_init( struct UG_file_handle* fh, struct UG_inode* inode, int flags );
 
-// free 
+// free
 int UG_file_handle_free( struct UG_file_handle* fh );
 
-// export an inode 
+// export an inode
 int UG_inode_export( struct md_entry* dest, struct UG_inode* src, uint64_t parent_id );
 int UG_inode_export_fs( struct fskit_core* fs, char const* fs_path, struct md_entry* inode_data );
 int UG_inode_export_xattrs( struct fskit_core* fs, struct UG_inode* inode, char*** ret_xattr_names, char*** ret_xattr_values, size_t** ret_xattr_value_lengths );
@@ -83,37 +83,37 @@ int UG_inode_export_match_version( struct UG_inode* dest, struct md_entry* src )
 int UG_inode_export_match_size( struct UG_inode* dest, struct md_entry* src );
 int UG_inode_export_match_type( struct UG_inode* dest, struct md_entry* src );
 
-// import an inode 
+// import an inode
 int UG_inode_import( struct UG_inode* dest, struct md_entry* src );
 
-// import blocks 
+// import blocks
 int UG_inode_manifest_merge_blocks( struct SG_gateway* gateway, struct UG_inode* inode, struct SG_manifest* new_manifest );
 
 // directly put dirty blocks
 int UG_inode_dirty_block_put( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block, bool replace );
 
-// get the modified dirty blocks from an inode 
+// get the modified dirty blocks from an inode
 int UG_inode_dirty_blocks_modified( struct UG_inode* inode, UG_dirty_block_map_t* modified );
 
 // add a dirty block and update our manifest
 int UG_inode_dirty_block_commit( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block );
 int UG_inode_dirty_block_update_manifest( struct SG_gateway* gateway, struct UG_inode* inode, struct UG_dirty_block* dirty_block );
 
-// eviction hints 
+// eviction hints
 int UG_file_handle_evict_add_hint( struct UG_file_handle* fh, uint64_t block_id, int64_t block_version );
 int UG_file_handle_evict_blocks( struct UG_file_handle* fh );
 
-// manifest 
+// manifest
 int UG_inode_manifest_replace( struct UG_inode* inode, struct SG_manifest* manifest );
 
-// truncate 
+// truncate
 int UG_inode_truncate_find_removed( struct SG_gateway* gateway, struct UG_inode* inode, off_t new_size, struct SG_manifest* removed );
 int UG_inode_truncate( struct SG_gateway* gateway, struct UG_inode* inode, off_t new_size, int64_t new_version, int64_t write_nonce, struct timespec* new_manifest_timestamp );
 
-// timestamps 
+// timestamps
 bool UG_inode_manifest_is_newer_than( struct SG_manifest* manifest, int64_t mtime_sec, int32_t mtime_nsec );
 
-// extraction 
+// extraction
 int UG_inode_dirty_blocks_extract( struct UG_inode* inode, UG_dirty_block_map_t* modified );
 int UG_inode_dirty_blocks_return( struct UG_inode* inode, UG_dirty_block_map_t* extracted );
 
@@ -122,12 +122,12 @@ int UG_inode_sync_queue_push( struct UG_inode* inode, struct UG_sync_context* sy
 struct UG_sync_context* UG_inode_sync_queue_pop( struct UG_inode* inode );
 int UG_inode_clear_replaced_blocks( struct UG_inode* inode );
 
-// locks 
+// locks
 int UG_inode_rlock( struct UG_inode* inode );
 int UG_inode_wlock( struct UG_inode* inode );
 int UG_inode_unlock( struct UG_inode* inode );
 
-// getters 
+// getters
 uint64_t UG_inode_volume_id( struct UG_inode* inode );
 uint64_t UG_inode_coordinator_id( struct UG_inode* inode );
 char* UG_inode_name( struct UG_inode* inode );
@@ -148,8 +148,8 @@ bool UG_inode_renaming( struct UG_inode* inode );
 bool UG_inode_deleting( struct UG_inode* inode );
 int64_t UG_inode_ms_num_children( struct UG_inode* inode );
 int64_t UG_inode_ms_capacity( struct UG_inode* inode );
-uint32_t UG_inode_max_read_freshness( struct UG_inode* inode );
-uint32_t UG_inode_max_write_freshness( struct UG_inode* inode );
+int32_t UG_inode_max_read_freshness( struct UG_inode* inode );
+int32_t UG_inode_max_write_freshness( struct UG_inode* inode );
 int64_t UG_inode_generation( struct UG_inode* inode );
 struct timespec UG_inode_refresh_time( struct UG_inode* inode );
 struct timespec UG_inode_manifest_refresh_time( struct UG_inode* inode );
@@ -171,8 +171,8 @@ void UG_inode_set_manifest_refresh_time_now( struct UG_inode* inode );
 void UG_inode_set_children_refresh_time( struct UG_inode* inode, struct timespec* ts );
 void UG_inode_set_children_refresh_time_now( struct UG_inode* inode );
 void UG_inode_set_old_manifest_modtime( struct UG_inode* inode, struct timespec* ts );
-void UG_inode_set_max_read_freshness( struct UG_inode* inode, uint32_t rf );
-void UG_inode_set_max_write_freshness( struct UG_inode* inode, uint32_t wf );
+void UG_inode_set_max_read_freshness( struct UG_inode* inode, int32_t rf );
+void UG_inode_set_max_write_freshness( struct UG_inode* inode, int32_t wf );
 void UG_inode_set_read_stale( struct UG_inode* inode, bool val );
 void UG_inode_set_deleting( struct UG_inode* inode, bool val );
 void UG_inode_set_dirty( struct UG_inode* inode, bool val );
@@ -185,7 +185,7 @@ void UG_inode_set_generation( struct UG_inode* inode, uint64_t generation );
 void UG_inode_bind_fskit_entry( struct UG_inode* inode, struct fskit_entry* ent );
 void UG_inode_preserve_old_manifest_modtime( struct UG_inode* inode );
 
-// publish 
+// publish
 int UG_inode_publish( struct SG_gateway* gateway, struct fskit_entry* fent, struct md_entry* ent_data, struct UG_inode** ret_inode_data );
 
 }

--- a/libsyndicate-ug/xattr.cpp
+++ b/libsyndicate-ug/xattr.cpp
@@ -73,13 +73,13 @@ static struct UG_xattr_handler_t xattr_handlers[] = {
 // return a pointer to the handler on success
 // return NULL if not found.
 static struct UG_xattr_handler_t* UG_xattr_lookup_handler( char const* name ) {
-   
+
    for( int i = 0; xattr_handlers[i].name != NULL; i++ ) {
       if( strcmp( xattr_handlers[i].name, name ) == 0 ) {
          return &xattr_handlers[i];
       }
    }
-   
+
    return NULL;
 }
 
@@ -87,14 +87,14 @@ static struct UG_xattr_handler_t* UG_xattr_lookup_handler( char const* name ) {
 // get size of all of the names of our xattrs
 // always succeeds
 size_t UG_xattr_builtin_len_all( void ) {
-   
+
    size_t len = 0;
-   
+
    for( int i = 0; xattr_handlers[i].name != NULL; i++ ) {
-      
+
       len += strlen(xattr_handlers[i].name) + 1;        // include '\0'
    }
-   
+
    return len;
 }
 
@@ -104,25 +104,25 @@ size_t UG_xattr_builtin_len_all( void ) {
 // return the number of bytes copied on success
 // return -ERANGE if the buffer is not big enough.
 ssize_t UG_xattr_get_builtin_names( char* buf, size_t buf_len ) {
-   
+
    size_t needed_len = UG_xattr_builtin_len_all();
-   
+
    if( needed_len > buf_len ) {
       return -ERANGE;
    }
-   
+
    ssize_t offset = 0;
-   
+
    for( int i = 0; xattr_handlers[i].name != NULL; i++ ) {
       sprintf( buf + offset, "%s", xattr_handlers[i].name );
-      
+
       offset += strlen(xattr_handlers[i].name);
-      
+
       *(buf + offset) = '\0';
-      
+
       offset ++;
    }
-   
+
    return offset;
 }
 
@@ -134,43 +134,43 @@ ssize_t UG_xattr_get_builtin_names( char* buf, size_t buf_len ) {
 // return -ERANGE if *buf is not NULL but buf_len is not long enough to hold the block vector
 // NOTE: fent must be at least read-locked
 static ssize_t UG_xattr_get_cached_blocks( struct fskit_core* core, struct fskit_entry* fent, char const* name, char* buf, size_t buf_len) {
-   
+
    struct local {
-      
+
       // callback to fskit_entry_resolve_path_cls
       // *cls is a pointer to the null-terminated block vector we're filling in
       // returns 0 on success
       // return -ENOMEM on OOM
       static int xattr_stat_block( char const* block_path, void* cls ) {
-         
+
          // NOTE: block_vector must be a null-terminated string, memset'ed to '0''s
          char* block_vector = (char*)cls;
          size_t num_blocks = strlen(block_vector);
-         
+
          // which block is this?
          char* block_name = md_basename( block_path, NULL );
          if( block_name == NULL ) {
-            
+
             return -ENOMEM;
          }
-         
+
          // try to parse the ID
          int64_t id = 0;
          int rc = sscanf( block_name, "%" PRId64, &id );
          if( rc == 1 ) {
-            
+
             // parsed!  This block is present
             if( (size_t)id < num_blocks ) {
                *(block_vector + id) = '1';
             }
          }
-         
+
          free( block_name );
-         
+
          return 0;
       }
    };
-   
+
    struct SG_gateway* gateway = (struct SG_gateway*)fskit_core_get_user_data( core );
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
@@ -178,48 +178,48 @@ static ssize_t UG_xattr_get_cached_blocks( struct fskit_core* core, struct fskit
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
    uint64_t volume_id = ms_client_get_volume_id( ms );
    uint64_t gateway_id = SG_gateway_id( gateway );
-   
+
    off_t num_blocks = (fskit_entry_get_size( fent ) / block_size) + ((fskit_entry_get_size( fent ) % block_size) == 0 ? 0 : 1);
    SG_debug("%" PRIX64 " has %jd blocks\n", UG_inode_file_id(inode), num_blocks);
 
    if( buf_len == 0 || buf == NULL ) {
-       // size query 
+       // size query
        return num_blocks + 1;
    }
    else if( (size_t)num_blocks >= buf_len + 1 ) {
-       // not enough space 
+       // not enough space
        return -ERANGE;
    }
 
    char* cached_file_path = NULL;
    ssize_t rc = 0;
-   
+
    char* cached_file_url = md_url_local_file_data_url( conf->data_root, volume_id, gateway_id, UG_inode_file_id( inode ), UG_inode_file_version( inode ) );
    if( cached_file_url == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    cached_file_path = SG_URL_LOCAL_PATH( cached_file_url );
-   
+
    // enough space...
    memset( buf, '0', buf_len );
    buf[buf_len - 1] = '\0';
-   
+
    rc = md_cache_file_blocks_apply( cached_file_path, local::xattr_stat_block, buf );
-   
+
    if( rc == 0 ) {
-      
+
       rc = num_blocks + 1;
    }
    else if( rc == -ENOENT ) {
-      
+
       // no cached data--all 0's
       SG_debug("No data cached for %" PRIX64 ".%" PRId64 " (%s)\n", UG_inode_file_id( inode ), UG_inode_file_version( inode ), cached_file_path );
-      
+
       memset( buf, '0', buf_len );
       buf[buf_len - 1] = '\0';
-      
+
       rc = num_blocks + 1;
    }
    else {
@@ -236,102 +236,102 @@ static ssize_t UG_xattr_get_cached_blocks( struct fskit_core* core, struct fskit
 // get cached file path.
 // fill it in in *buf
 // return the length of the path (including the '\0') on success, and fill in *buf if it is not NULL
-// return -ERANGE if the buf is not NULL and the buffer is not long enough 
+// return -ERANGE if the buf is not NULL and the buffer is not long enough
 // return -ENOMEM on OOM
 // NOTE: fent must be read-locked
 static ssize_t UG_xattr_get_cached_file_path( struct fskit_core* core, struct fskit_entry* fent, char const* name, char* buf, size_t buf_len) {
-   
+
    char* cached_file_path = NULL;
    size_t len = 0;
-   
+
    struct SG_gateway* gateway = (struct SG_gateway*)fskit_core_get_user_data( core );
    struct ms_client* ms = SG_gateway_ms( gateway );
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
    uint64_t volume_id = ms_client_get_volume_id( ms );
    uint64_t gateway_id = SG_gateway_id( gateway );
-   
+
    char* cached_file_url = md_url_local_file_data_url( conf->data_root, volume_id, gateway_id, UG_inode_file_id( inode ), UG_inode_file_version( inode ) );
    if( cached_file_url == NULL ) {
-      
+
       return -ENOMEM;
    }
 
    cached_file_path = SG_URL_LOCAL_PATH( cached_file_url );
-   
+
    len = strlen(cached_file_path);
-   
+
    if( buf_len == 0 || buf == NULL ) {
-      
+
       // size query
       free( cached_file_url );
       return len + 1;         // NULL-terminated
    }
 
    if( (size_t)len >= buf_len ) {
-      
-      // not enough space 
+
+      // not enough space
       free( cached_file_url );
       return -ERANGE;
    }
-   
+
    // enough space...
    if( buf_len > 0 ) {
-      
+
       strcpy( buf, cached_file_path );
    }
-   
+
    free( cached_file_url );
-   
+
    return len + 1;
 }
 
 
-// get the name of a coordinator of a file 
+// get the name of a coordinator of a file
 // return the length of the coordinator's name (plus the '\0'), and write it to *buf if buf is not NULL
-// return -ERANGE if *buf is not NULL but not long enough 
+// return -ERANGE if *buf is not NULL but not long enough
 // return -ENOATTR if the coordinator is not known to us (e.g. we're refreshing our cert bundle)
 // return -ENOMEM if OOM
 // NOTE: fent must be read-locked
 static ssize_t UG_xattr_get_coordinator( struct fskit_core* core, struct fskit_entry* fent, char const* name, char* buf, size_t buf_len ) {
-   
+
    int rc = 0;
    char* gateway_name = NULL;
-   
+
    struct SG_gateway* gateway = (struct SG_gateway*)fskit_core_get_user_data( core );
    struct ms_client* ms = SG_gateway_ms( gateway );
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    rc = ms_client_get_gateway_name( ms, UG_inode_coordinator_id( inode ), &gateway_name );
-   
+
    if( rc != 0 || gateway_name == NULL ) {
-      
+
       return -ENOATTR;
    }
    else {
-      
+
       if( buf == NULL || buf_len == 0 ) {
-         
+
          // query for size
          size_t len = strlen(gateway_name) + 1;
          free( gateway_name );
-         
+
          return (ssize_t)len;
       }
-      
+
       if( strlen(gateway_name) >= buf_len ) {
-         
+
          // not big enough
          free( gateway_name );
          return -ERANGE;
       }
-      
+
       size_t len = strlen(gateway_name) + 1;
-      
+
       strcpy( buf, gateway_name );
-      
+
       free( gateway_name );
-      
+
       return (ssize_t)len;
    }
 }
@@ -339,127 +339,127 @@ static ssize_t UG_xattr_get_coordinator( struct fskit_core* core, struct fskit_e
 
 // get the read ttl as a string
 // return the string length (plus '\0') on success, and write the string to *buf if buf is not NULL
-// return -ERANGE if buf is not NULL but not long enough 
+// return -ERANGE if buf is not NULL but not long enough
 // NOTE: fent must be read-locked
 static ssize_t UG_xattr_get_read_ttl( struct fskit_core* core, struct fskit_entry* fent, char const* name, char* buf, size_t buf_len ) {
-   
+
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
-   uint32_t read_ttl = UG_inode_max_read_freshness( inode );
-   
+
+   int32_t read_ttl = UG_inode_max_read_freshness( inode );
+
    // how many bytes needed?
    ssize_t len = 2;
    if( read_ttl > 0 ) {
       len = (ssize_t)(log( (double)read_ttl )) + 1;
    }
-   
+
    if( buf == NULL || buf_len == 0 ) {
       // size query
       return len;
    }
-   
+
    if( (size_t)len > buf_len ) {
       // not big enough
       return -ERANGE;
    }
-   
+
    sprintf( buf, "%u", read_ttl );
-   
+
    return len;
 }
 
 
-// get the write ttl 
+// get the write ttl
 // return the string length (plus '\0') on success, and write the string to *buf if buf is not NULL
-// return -ERANGE if buf is not NULL, but not long enough 
+// return -ERANGE if buf is not NULL, but not long enough
 static ssize_t UG_xattr_get_write_ttl( struct fskit_core* core, struct fskit_entry* fent, char const* name, char* buf, size_t buf_len ) {
-   
+
    struct UG_inode* inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
-   uint32_t write_ttl = UG_inode_max_write_freshness( inode );
-   
+
+   int32_t write_ttl = UG_inode_max_write_freshness( inode );
+
    // how many bytes needed?
    ssize_t len = 2;
    if( write_ttl > 0 ) {
-      
+
       len = (ssize_t)(log( (double)write_ttl )) + 1;
    }
-   
+
    if( buf == NULL || buf_len == 0 ) {
-      
+
       // size query
       return len;
    }
-   
+
    if( (size_t)len > buf_len ) {
-      
+
       // not big enough
       return -ERANGE;
    }
-   
+
    sprintf( buf, "%u", write_ttl );
-   
+
    return len;
 }
 
 
-// set the read ttl 
+// set the read ttl
 // return 0 on success
-// return -EEXIST if the caller specified XATTR_CREATE--this attribute is built-in and always exists 
+// return -EEXIST if the caller specified XATTR_CREATE--this attribute is built-in and always exists
 // return -EINVAL if we couldn't parse the buffer
 // NOTE: fent must be write-locked
 static int UG_xattr_set_read_ttl( struct fskit_core* core, struct fskit_entry* fent, char const* name, char const* buf, size_t buf_len, int flags ) {
-   
+
    // this attribute always exists...
    if( (flags & XATTR_CREATE) ) {
       return -EEXIST;
    }
-   
+
    // parse this
    struct UG_inode* inode = NULL;
    char* tmp = NULL;
    uint32_t read_ttl = (uint32_t)strtoll( buf, &tmp, 10 );
-   
+
    if( tmp == buf || *tmp != '\0' ) {
-      // invalid 
+      // invalid
       return -EINVAL;
    }
-   
+
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    UG_inode_set_max_read_freshness( inode, read_ttl );
-   
+
    return 0;
 }
 
 
-// set the write ttl 
-// return 0 on success 
-// return -EEXIST if the caller specified XATTR_CREAT--this attribute is built-in and always exists 
-// return -EINVAL if we couldn't parse the buffer 
+// set the write ttl
+// return 0 on success
+// return -EEXIST if the caller specified XATTR_CREAT--this attribute is built-in and always exists
+// return -EINVAL if we couldn't parse the buffer
 // NOTE: fent must be write-locked
 static int UG_xattr_set_write_ttl( struct fskit_core* core, struct fskit_entry* fent, char const* name, char const* buf, size_t buf_len, int flags ) {
-   
+
    // this attribute always exists...
    if( (flags & XATTR_CREATE) ) {
       return -EEXIST;
    }
-   
+
    // parse this
    struct UG_inode* inode = NULL;
    char* tmp = NULL;
-   uint32_t write_ttl = (uint32_t)strtoll( buf, &tmp, 10 );
-   
+   int32_t write_ttl = (int32_t)strtoll( buf, &tmp, 10 );
+
    if( tmp == buf || *tmp != '\0' ) {
-      
-      // invalid 
+
+      // invalid
       return -EINVAL;
    }
-   
+
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    UG_inode_set_max_write_freshness( inode, write_ttl );
-   
+
    return 0;
 }
 
@@ -473,7 +473,7 @@ static int UG_xattr_set_write_ttl( struct fskit_core* core, struct fskit_entry* 
 // return -ERANGE if the buf isn't big enough
 // fent must be read-locked
 static ssize_t UG_xattr_fgetxattr_builtin( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char const* name, char* value, size_t value_len ) {
-    
+
    int rc = 0;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
@@ -482,7 +482,7 @@ static ssize_t UG_xattr_fgetxattr_builtin( struct SG_gateway* gateway, char cons
       // not handled
       SG_debug("xattr '%s' is NOT built-in\n", name);
       return 0;
-   } 
+   }
 
    rc = (*handler->get)( fs, fent, name, value, value_len );
    return rc;
@@ -513,41 +513,41 @@ ssize_t UG_xattr_fgetxattr_ex( struct SG_gateway* gateway, char const* path, str
 
    char* value_buf = NULL;
    size_t xattr_buf_len = 0;
- 
-   // built-in? 
+
+   // built-in?
    rc = UG_xattr_fgetxattr_builtin( gateway, path, fent, name, value, size );
    if( rc != 0 ) {
        // handled!
        return rc;
    }
-    
+
    if( coordinator_id == SG_gateway_id( gateway ) ) {
        // local (built-in or otherwise)
        rc = UG_xattr_fgetxattr_builtin( gateway, path, fent, name, value, size );
        return rc;
    }
-   else if( query_remote ) { 
-      
+   else if( query_remote ) {
+
        // go get the xattr remotely
        rc = SG_client_getxattr( gateway, coordinator_id, path, file_id, file_version, name, xattr_nonce, &value_buf, &xattr_buf_len );
        if( rc != 0 ) {
-       
+
            SG_error("SG_client_getxattr('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, file_id, file_version, xattr_nonce, name, rc );
        }
-   
+
        if( value != NULL ) {
-       
+
           if( xattr_buf_len <= size ) {
              memcpy( value, value_buf, xattr_buf_len );
              rc = xattr_buf_len;
           }
           else {
-          
+
              rc = -ERANGE;
           }
        }
        else {
-      
+
           rc = xattr_buf_len;
        }
        SG_safe_free( value_buf );
@@ -570,29 +570,29 @@ ssize_t UG_xattr_fgetxattr( struct SG_gateway* gateway, char const* path, struct
 // handles all xattrs--local and remote, builtin and non-built-in.
 // return the length of the xattr value on success
 // return the length of the xattr value if *value is NULL, but we were able to get the xattr
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -ENOENT if the file doesn't exist
 // return -EACCES if we're not allowed to read the file or the attribute
-// return -ETIMEDOUT if the transfer could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the remote host couldn't process the request 
+// return -ETIMEDOUT if the transfer could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the remote host couldn't process the request
 ssize_t UG_xattr_getxattr_ex( struct SG_gateway* gateway, char const* path, char const *name, char *value, size_t size, uint64_t owner_id, uint64_t volume_id, bool query_remote ) {
-   
+
    int rc = 0;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    // revalidate...
    rc = UG_consistency_path_ensure_fresh( gateway, path );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    // look up...
    struct fskit_entry* fent = fskit_entry_resolve_path( fs, path, owner_id, volume_id, false, &rc );
    if( fent == NULL ) {
-      
+
       return rc;
    }
 
@@ -600,7 +600,7 @@ ssize_t UG_xattr_getxattr_ex( struct SG_gateway* gateway, char const* path, char
    rc = UG_xattr_fgetxattr_ex( gateway, path, fent, name, value, size, query_remote );
    if( rc == 0 ) {
 
-      // not built-in 
+      // not built-in
       // get from inode directly
       rc = fskit_xattr_fgetxattr( fs, fent, name, value, size );
    }
@@ -619,7 +619,7 @@ ssize_t UG_xattr_getxattr( struct SG_gateway* gateway, char const* path, char co
 // return -ENOMEM on OOM
 // fent must be read-locked
 static ssize_t UG_xattr_fsetxattr_builtin( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char const* name, char const* value, size_t value_len, int flags ) {
-    
+
    int rc = 0;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
@@ -627,7 +627,7 @@ static ssize_t UG_xattr_fsetxattr_builtin( struct SG_gateway* gateway, char cons
    if( handler == NULL || handler->set == UG_xattr_set_undefined ) {
       // not handled
       return 1;
-   } 
+   }
 
    rc = (*handler->set)( fs, fent, name, value, value_len, flags );
    return rc;
@@ -635,13 +635,13 @@ static ssize_t UG_xattr_fsetxattr_builtin( struct SG_gateway* gateway, char cons
 
 
 // local setxattr, for when we're the coordinator of the file.
-// return 0 on success 
-// return -ENOMEM on OOM 
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// return 0 on success
+// return -ENOMEM on OOM
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
 // NOTE: inode->entry must be write-locked
 static int UG_xattr_setxattr_local( struct SG_gateway* gateway, char const* path, struct UG_inode* inode, char const* name, char const* value, size_t value_len, int flags ) {
-    
+
     int rc = 0;
     struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
     struct fskit_core* fs = UG_state_fs( ug );
@@ -649,9 +649,9 @@ static int UG_xattr_setxattr_local( struct SG_gateway* gateway, char const* path
     struct md_entry inode_data;
     int64_t cur_xattr_nonce = 0;
     unsigned char xattr_hash[ SHA256_DIGEST_LENGTH ];
-    
+
     memset( &inode_data, 0, sizeof(struct md_entry) );
-    
+
     // get inode info
     rc = UG_inode_export( &inode_data, inode, 0 );
     if( rc != 0 ) {
@@ -659,14 +659,14 @@ static int UG_xattr_setxattr_local( struct SG_gateway* gateway, char const* path
         return rc;
     }
 
-    // get new xattr hash, for the *next* nonce value 
+    // get new xattr hash, for the *next* nonce value
     cur_xattr_nonce = UG_inode_xattr_nonce( inode );
     UG_inode_set_xattr_nonce( inode, cur_xattr_nonce + 1 );
     rc = UG_inode_export_xattr_hash( fs, SG_gateway_id( gateway ), inode, xattr_hash );
     UG_inode_set_xattr_nonce( inode, cur_xattr_nonce );
 
     if( rc != 0 ) {
-        
+
         md_entry_free( &inode_data );
         return rc;
     }
@@ -674,86 +674,86 @@ static int UG_xattr_setxattr_local( struct SG_gateway* gateway, char const* path
     // propagate new xattr hash
     inode_data.xattr_hash = xattr_hash;
     inode_data.xattr_nonce = cur_xattr_nonce + 1;
-    
+
     // put on the MS...
     rc = ms_client_putxattr( ms, &inode_data, name, value, value_len, xattr_hash );
-    
-    inode_data.xattr_hash = NULL;       // NOTE: don't free this 
-    
+
+    inode_data.xattr_hash = NULL;       // NOTE: don't free this
+
     if( rc != 0 ) {
-        
+
         SG_error("ms_client_putxattr('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, inode_data.file_id, inode_data.version, inode_data.xattr_nonce, name, rc );
     }
-    
+
     // propagate new xattr info from MS
     UG_inode_set_xattr_nonce( inode, inode_data.xattr_nonce );
     UG_inode_set_ms_xattr_hash( inode, xattr_hash );
 
     md_entry_free( &inode_data );
-    
+
     return rc;
 }
 
 
-// remote setxattr, for when we're NOT the coordinator of the file 
-// return 0 on success 
-// return -ENOMEM on OOM 
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// remote setxattr, for when we're NOT the coordinator of the file
+// return 0 on success
+// return -ENOMEM on OOM
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // NOTE: inode->entry must be at least read-locked
 static int UG_xattr_setxattr_remote( struct SG_gateway* gateway, char const* path, struct UG_inode* inode, char const* name, char const* value, size_t value_len, int flags ) {
-    
+
     int rc = 0;
     SG_messages::Request request;
     SG_messages::Reply reply;
     struct SG_request_data reqdat;
-    
+
     uint64_t file_id = UG_inode_file_id( inode );
     uint64_t coordinator_id = UG_inode_coordinator_id( inode );
     int64_t file_version = UG_inode_file_version( inode );
     int64_t xattr_nonce = UG_inode_xattr_nonce( inode );
-    
+
     rc = SG_request_data_init_setxattr( gateway, path, file_id, file_version, xattr_nonce, name, value, value_len, &reqdat );
     if( rc != 0 ) {
         return rc;
     }
-   
+
     rc = SG_client_request_SETXATTR_setup( gateway, &request, &reqdat, UG_inode_coordinator_id( inode ), name, value, value_len, flags );
     if( rc != 0 ) {
-        
+
         SG_request_data_free( &reqdat );
         return rc;
     }
-    
+
     rc = SG_client_request_send( gateway, coordinator_id, &request, NULL, &reply );
     SG_request_data_free( &reqdat );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("SG_client_send_request(SETXATTR %" PRIu64 ", '%s') rc = %d\n", coordinator_id, name, rc );
         return rc;
     }
-    
+
     // success!
     return rc;
 }
 
 
 // fsetxattr implementation, used by the client, the HTTP server, and fskit
-// handles both remote and local xattrs, as well as built-in and non-built-in. 
+// handles both remote and local xattrs, as well as built-in and non-built-in.
 // return 0 if handled
 // return 1 if not handled
 // return -ENOMEM on OOM
 // return -EPERM if this gateway is anonymous
 // return -ETIMEDOUT on timeout
-// return -EREMOTEIO on failure to process remotely 
+// return -EREMOTEIO on failure to process remotely
 // return -EAGAIN if we're acting on stale data
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // fent must be write-locked
 int UG_xattr_fsetxattr( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char const* name, char const* value, size_t size, int flags ) {
 
@@ -761,12 +761,12 @@ int UG_xattr_fsetxattr( struct SG_gateway* gateway, char const* path, struct fsk
    struct UG_inode* inode = NULL;
 
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    uint64_t coordinator_id = UG_inode_coordinator_id( inode );
    uint64_t file_id = UG_inode_file_id( inode );
    int64_t file_version = UG_inode_file_version( inode );
    int64_t xattr_nonce = UG_inode_xattr_nonce( inode );
-    
+
    if( SG_gateway_id( gateway ) == SG_GATEWAY_ANON ) {
       return -EPERM;
    }
@@ -786,19 +786,19 @@ int UG_xattr_fsetxattr( struct SG_gateway* gateway, char const* path, struct fsk
    }
 
    if( coordinator_id == SG_gateway_id( gateway ) ) {
-      
+
        // set the xattr on the MS, and tell caller to do the set locally
        rc = UG_xattr_setxattr_local( gateway, path, inode, name, value, size, flags );
        if( rc < 0 ) {
            SG_error("UG_xattr_setxattr_local('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, file_id, file_version, xattr_nonce, name, rc );
            goto UG_xattr_fsetxattr_out;
        }
-        
+
        rc = 1;
    }
    else {
-       
-       // if we're not the coordinator, send the xattr to the coordinator 
+
+       // if we're not the coordinator, send the xattr to the coordinator
        rc = UG_xattr_setxattr_remote( gateway, path, inode, name, value, size, flags );
        if( rc != 0 ) {
            SG_error("UG_xattr_setxattr_remote('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, file_id, file_version, xattr_nonce, name, rc );
@@ -807,7 +807,7 @@ int UG_xattr_fsetxattr( struct SG_gateway* gateway, char const* path, struct fsk
 
        rc = 1;
    }
-   
+
 
 UG_xattr_fsetxattr_out:
    if( rc < 0 && rc != -EACCES && rc != -ENOENT && rc != -ETIMEDOUT && rc != -ENOMEM && rc != -EAGAIN && rc != -ENOATTR && rc != -EEXIST ) {
@@ -816,42 +816,42 @@ UG_xattr_fsetxattr_out:
 
    return rc;
 
-} 
+}
 
 
 // setxattr(2)
 // works for the HTTP server and client, but not for fskit
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -ENOENT if the file doesn't exist
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
 // return -EACCES if we're not allowed to write to the file
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // return -ESTALE if ask_remote is False and we're not the coordinator
 int UG_xattr_setxattr_ex( struct SG_gateway* gateway, char const* path, char const *name, char const *value, size_t size, int flags, uint64_t user, uint64_t volume, bool query_remote ) {
-   
+
    int rc = 0;
    struct fskit_entry* fent = NULL;
    struct UG_inode* inode = NULL;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    if( SG_gateway_id( gateway ) == SG_GATEWAY_ANON ) {
       return -EPERM;
    }
-   
+
    rc = UG_consistency_path_ensure_fresh( gateway, path );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    fent = fskit_entry_resolve_path( fs, path, user, volume, true, &rc );
    if( fent == NULL ) {
-      
+
       return rc;
    }
 
@@ -861,7 +861,7 @@ int UG_xattr_setxattr_ex( struct SG_gateway* gateway, char const* path, char con
       fskit_entry_unlock( fent );
       return -ESTALE;
    }
-   
+
    rc = UG_xattr_fsetxattr( gateway, path, fent, name, value, size, flags );
    if( rc > 0 ) {
       // sync'ed with the MS.  Pass along to fskit.
@@ -883,9 +883,9 @@ int UG_xattr_setxattr( struct SG_gateway* gateway, char const* path, char const 
 // return -ERANGE if the buf isn't big enough
 // fent must be read-locked
 static ssize_t UG_xattr_flistxattr_builtin( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char* buf, size_t buf_len ) {
-    
+
    size_t builtin_len = UG_xattr_builtin_len_all();
-   
+
    if( buf == NULL || buf_len == 0 ) {
       return builtin_len;
    }
@@ -912,7 +912,7 @@ static ssize_t UG_xattr_flistxattr_builtin( struct SG_gateway* gateway, char con
 ssize_t UG_xattr_flistxattr_ex( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char* buf, size_t buf_len, bool query_remote ) {
 
    int rc = 0;
-   
+
    uint64_t file_id = 0;
    int64_t file_version = 0;
    int64_t xattr_nonce = 0;
@@ -926,14 +926,14 @@ ssize_t UG_xattr_flistxattr_ex( struct SG_gateway* gateway, char const* path, st
    char* buf_off = NULL;
 
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    file_id = UG_inode_file_id( inode );
    file_version = UG_inode_file_version( inode );
    xattr_nonce = UG_inode_xattr_nonce( inode );
    coordinator_id = UG_inode_coordinator_id( inode );
-   
+
    if( coordinator_id == SG_gateway_id( gateway ) ) {
-       
+
        // provide built-in xattrs
        rc = UG_xattr_flistxattr_builtin( gateway, path, fent, buf, buf_len );
        if( rc < 0 ) {
@@ -966,7 +966,7 @@ ssize_t UG_xattr_flistxattr_ex( struct SG_gateway* gateway, char const* path, st
    }
    else if( query_remote ) {
 
-       // ask the coordinator 
+       // ask the coordinator
        rc = SG_client_listxattrs( gateway, coordinator_id, path, file_id, file_version, xattr_nonce, &list_buf, &list_buf_len );
        if( rc < 0 ) {
            SG_error("SG_client_listxattrs('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ")) rc = %d\n", path, file_id, file_version, xattr_nonce, rc );
@@ -985,7 +985,7 @@ ssize_t UG_xattr_flistxattr_ex( struct SG_gateway* gateway, char const* path, st
 
            SG_safe_free( list_buf );
        }
-   } 
+   }
    else {
 
       rc = -ESTALE;
@@ -1008,31 +1008,31 @@ ssize_t UG_xattr_flistxattr( struct SG_gateway* gateway, char const* path, struc
 // listxattr(2)--get back a list of xattrs from the MS (for the client and HTTP server)
 // return the number of bytes copied on success, and fill in *list (if non-null) with \0-separated names for xattrs (up to size bytes)
 // return the number of bytes needed for *list, if *list is NULL
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -ENOENT if the file doesn't exist
 // return -ERANGE if list is not NULL, but too small
 // return -EACCES if we're not allowed to write to the file
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // return -ESTALE if ask_remote is False, and we're not the coordinator
 ssize_t UG_xattr_listxattr_ex( struct SG_gateway* gateway, char const* path, char *list, size_t size, uint64_t user, uint64_t volume, bool query_remote ) {
-   
+
    int rc = 0;
-   
+
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
    struct fskit_entry* fent = NULL;
    struct UG_inode* inode = NULL;
-      
+
    rc = UG_consistency_path_ensure_fresh( gateway, path );
    if( rc != 0 ) {
-      
+
       SG_error("UG_consistency_path_ensure_fresh('%s') rc = %d\n", path, rc );
       return rc;
    }
-   
+
    fent = fskit_entry_resolve_path( fs, path, user, volume, false, &rc );
    if( fent == NULL ) {
       return rc;
@@ -1065,7 +1065,7 @@ ssize_t UG_xattr_listxattr( struct SG_gateway* gateway, char const* path, char *
 // return -EACCES if we're not allowed to read the file or attribute
 // fent must be read-locked
 static ssize_t UG_xattr_fremovexattr_builtin( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char const* name ) {
-    
+
    int rc = 0;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
@@ -1073,7 +1073,7 @@ static ssize_t UG_xattr_fremovexattr_builtin( struct SG_gateway* gateway, char c
    if( handler == NULL || handler->del == UG_xattr_del_undefined ) {
       // not handled
       return 1;
-   } 
+   }
 
    rc = (*handler->del)( fs, fent, name );
    return rc;
@@ -1082,17 +1082,17 @@ static ssize_t UG_xattr_fremovexattr_builtin( struct SG_gateway* gateway, char c
 
 // local removexattr, for when we're the coordinator of the file.
 // NOTE: the xattr must have already been removed from the file
-// return 0 on success 
-// return -ENOMEM on OOM 
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// return 0 on success
+// return -ENOMEM on OOM
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // NOTE: inode->entry must be at least read-locked
 static int UG_xattr_removexattr_local( struct SG_gateway* gateway, char const* path, struct UG_inode* inode, char const* name ) {
-    
+
     int rc = 0;
     struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
     struct fskit_core* fs = UG_state_fs( ug );
@@ -1100,9 +1100,9 @@ static int UG_xattr_removexattr_local( struct SG_gateway* gateway, char const* p
     struct md_entry inode_data;
     int64_t cur_xattr_nonce = 0;
     unsigned char xattr_hash[ SHA256_DIGEST_LENGTH ];
-    
+
     memset( &inode_data, 0, sizeof(struct md_entry) );
-    
+
     // get inode info
     rc = UG_inode_export( &inode_data, inode, 0 );
     if( rc != 0 ) {
@@ -1110,14 +1110,14 @@ static int UG_xattr_removexattr_local( struct SG_gateway* gateway, char const* p
         return rc;
     }
 
-    // get new xattr hash, for the *next* nonce value 
+    // get new xattr hash, for the *next* nonce value
     cur_xattr_nonce = UG_inode_xattr_nonce( inode );
     UG_inode_set_xattr_nonce( inode, cur_xattr_nonce + 1 );
     rc = UG_inode_export_xattr_hash( fs, SG_gateway_id( gateway ), inode, xattr_hash );
     UG_inode_set_xattr_nonce( inode, cur_xattr_nonce );
 
     if( rc != 0 ) {
-        
+
         md_entry_free( &inode_data );
         return rc;
     }
@@ -1125,72 +1125,72 @@ static int UG_xattr_removexattr_local( struct SG_gateway* gateway, char const* p
     // propagate new xattr hash
     inode_data.xattr_hash = xattr_hash;
     inode_data.xattr_nonce = cur_xattr_nonce + 1;
-    
+
     // put on the MS...
     rc = ms_client_removexattr( ms, &inode_data, name, xattr_hash );
-    
-    inode_data.xattr_hash = NULL;       // NOTE: don't free this 
-    
+
+    inode_data.xattr_hash = NULL;       // NOTE: don't free this
+
     if( rc != 0 ) {
-        
+
         SG_error("ms_client_removexattr('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, inode_data.file_id, inode_data.version, inode_data.xattr_nonce, name, rc );
     }
-    
+
     // propagate new xattr info from MS
     UG_inode_set_xattr_nonce( inode, inode_data.xattr_nonce );
     UG_inode_set_ms_xattr_hash( inode, xattr_hash );
 
     md_entry_free( &inode_data );
-    
+
     return rc;
 }
 
 
-// remote removexattr, for when we're NOT the coordinator of the file 
-// return 0 on success 
-// return -ENOMEM on OOM 
-// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed 
+// remote removexattr, for when we're NOT the coordinator of the file
+// return 0 on success
+// return -ENOMEM on OOM
+// return -EEXIST if the XATTR_CREATE flag was set but the attribute existed
 // return -ENOATTR if the XATTR_REPLACE flag was set but the attribute did not exist
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // NOTE: inode->entry must be at least read-locked
 static int UG_xattr_removexattr_remote( struct SG_gateway* gateway, char const* path, struct UG_inode* inode, char const* name ) {
-    
+
     int rc = 0;
     SG_messages::Request request;
     SG_messages::Reply reply;
     struct SG_request_data reqdat;
-    
+
     uint64_t file_id = UG_inode_file_id( inode );
     uint64_t coordinator_id = UG_inode_coordinator_id( inode );
     int64_t file_version = UG_inode_file_version( inode );
     int64_t xattr_nonce = UG_inode_xattr_nonce( inode );
-    
+
     rc = SG_request_data_init_removexattr( gateway, path, file_id, file_version, xattr_nonce, name, &reqdat );
     if( rc != 0 ) {
         SG_error("SG_request_data_init_removexattr('%s', '%s') rc = %d\n", path, name, rc );
         return rc;
     }
-    
+
     rc = SG_client_request_REMOVEXATTR_setup( gateway, &request, &reqdat, UG_inode_coordinator_id( inode ), name );
     if( rc != 0 ) {
-        
+
         SG_request_data_free( &reqdat );
         SG_error("SG_request_REMOVEXATTR_setup('%s', '%s') rc = %d\n", path, name, rc );
         return rc;
     }
-    
+
     rc = SG_client_request_send( gateway, coordinator_id, &request, NULL, &reply );
     SG_request_data_free( &reqdat );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("SG_client_send_request(REMOVEXATTR %" PRIu64 ", '%s') rc = %d\n", coordinator_id, name, rc );
         return rc;
     }
-    
+
     // success!
     return rc;
 }
@@ -1209,24 +1209,24 @@ static int UG_xattr_removexattr_remote( struct SG_gateway* gateway, char const* 
 // return -ENOATTR if the attribute doesn't exist
 // return -EREMOTEIO if the the remote servers couldn't process the request
 // return -ESTALE if query_remote is False and we're not the coordinator
-// fent must be write-locked 
+// fent must be write-locked
 int UG_xattr_fremovexattr_ex( struct SG_gateway* gateway, char const* path, struct fskit_entry* fent, char const* name, bool query_remote ) {
 
    int rc = 0;
    struct UG_inode* inode = NULL;
- 
+
    if( SG_gateway_id( gateway ) == SG_GATEWAY_ANON ) {
       return -EPERM;
    }
 
    // not a built-in
    inode = (struct UG_inode*)fskit_entry_get_user_data( fent );
-   
+
    uint64_t coordinator_id = UG_inode_coordinator_id( inode );
    uint64_t file_id = UG_inode_file_id( inode );
    int64_t file_version = UG_inode_file_version( inode );
    int64_t xattr_nonce = UG_inode_xattr_nonce( inode );
-   
+
    // built-in?
    rc = UG_xattr_fremovexattr_builtin( gateway, path, fent, name );
    if( rc <= 0 ) {
@@ -1237,16 +1237,16 @@ int UG_xattr_fremovexattr_ex( struct SG_gateway* gateway, char const* path, stru
          SG_debug("UG_xattr_fremovexattr_builtin(%s, '%s') handled\n", path, name );
       }
 
-      // handled or error 
+      // handled or error
       goto UG_xattr_fremovexattr_out;
    }
 
    if( coordinator_id == SG_gateway_id( gateway ) ) {
-      
+
       // not built-in. remove from MS
       rc = UG_xattr_removexattr_local( gateway, path, inode, name );
       if( rc != 0 ) {
-           
+
           SG_error("UG_xattr_removexattr_local('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, file_id, file_version, xattr_nonce, name, rc );
           goto UG_xattr_fremovexattr_out;
       }
@@ -1254,12 +1254,12 @@ int UG_xattr_fremovexattr_ex( struct SG_gateway* gateway, char const* path, stru
       rc = 1;
    }
    else if( query_remote ) {
-       
+
        // if we're not the coordinator, send the remove request to the coordinator
-       SG_debug("Ask %" PRIu64 " to remove '%s'\n", coordinator_id, name ); 
+       SG_debug("Ask %" PRIu64 " to remove '%s'\n", coordinator_id, name );
        rc = UG_xattr_removexattr_remote( gateway, path, inode, name );
        if( rc != 0 ) {
-           
+
            SG_error("UG_xattr_removexattr_remote('%s' (%" PRIX64 ".%" PRId64 ".%" PRId64 ") '%s') rc = %d\n", path, file_id, file_version, xattr_nonce, name, rc );
            goto UG_xattr_fremovexattr_out;
        }
@@ -1286,42 +1286,42 @@ int UG_xattr_fremovexattr( struct SG_gateway* gateway, char const* path, struct 
 
 // removexattr(2)--delete an xattr on the MS and locally
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EPERM if this is an anonymous gateway
 // return -ENOENT if the file doesn't exist
 // return -ERANGE if list is not NULL, but too small
 // return -EACCES if we're not allowed to write to the file
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -EPROTO on HTTP 400-level error
 // return -ESTALE if query_remote is False and we're not the coordinator
 int UG_xattr_removexattr_ex( struct SG_gateway* gateway, char const* path, char const *name, uint64_t user, uint64_t volume, bool query_remote ) {
-   
+
    int rc = 0;
    struct fskit_entry* fent = NULL;
    struct UG_state* ug = (struct UG_state*)SG_gateway_cls( gateway );
    struct fskit_core* fs = UG_state_fs( ug );
-   
+
    if( SG_gateway_id( gateway ) == SG_GATEWAY_ANON ) {
       return -EPERM;
    }
-   
+
    rc = UG_consistency_path_ensure_fresh( gateway, path );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    fent = fskit_entry_resolve_path( fs, path, user, volume, true, &rc );
    if( fent == NULL ) {
-      
+
       return rc;
    }
 
    rc = UG_xattr_fremovexattr_ex( gateway, path, fent, name, query_remote );
    if( rc > 0 ) {
-      // pass along to fskit 
+      // pass along to fskit
       rc = fskit_xattr_fremovexattr( fs, fent, name );
       if( rc == -ENOATTR ) {
          // not a problem if UG_xattr_fremovexattr_ex succeeded
@@ -1336,4 +1336,3 @@ int UG_xattr_removexattr_ex( struct SG_gateway* gateway, char const* path, char 
 int UG_xattr_removexattr( struct SG_gateway* gateway, char const* path, char const* name, uint64_t user, uint64_t volume ) {
    return UG_xattr_removexattr_ex( gateway, path, name, user, volume, true );
 }
-

--- a/libsyndicate/client.cpp
+++ b/libsyndicate/client.cpp
@@ -26,27 +26,27 @@ static char const* SG_post_field_control = SG_SERVER_POST_FIELD_CONTROL_PLANE;
 
 // extra data to include in a write
 struct SG_client_WRITE_data {
-    
+
     bool has_write_delta;
     struct SG_manifest* write_delta;
-    
+
     bool has_mtime;
     struct timespec mtime;
-    
+
     bool has_mode;
     mode_t mode;
-   
+
     bool has_new_size;
     uint64_t new_size;
-     
+
     bool has_owner_id;
     uint64_t owner_id;
 
     bool has_consistency;
-    uint64_t max_read_freshness;
-    uint64_t max_write_freshness;
-    
-    // routing information--can be set separately, but will be imported from write_delta if not given 
+    int32_t max_read_freshness;
+    int32_t max_write_freshness;
+
+    // routing information--can be set separately, but will be imported from write_delta if not given
     bool has_routing_information;
     uint64_t coordinator_id;
     uint64_t volume_id;
@@ -54,16 +54,16 @@ struct SG_client_WRITE_data {
     int64_t file_version;
 };
 
-// per-request state to be preserved for running multiple requests 
+// per-request state to be preserved for running multiple requests
 struct SG_client_request_cls {
-   
+
    uint64_t chunk_id;                   // ID of the chunk we're transfering
    SG_messages::Request* message;       // the original control-plane message (if uploading)
    uint64_t dest_gateway_id;            // gateway that was supposed to receive the message
    char* serialized_message;            // serialized control-plane message (if uploading)
    struct curl_httppost* form_begin;    // curl forms (if uploading)
-   char* url;                           // target URL 
-   
+   char* url;                           // target URL
+
    void* cls;                           // user-given download state
    void (*free_cls)( void* cls );       // cleanup handler for user-given download state
 };
@@ -77,25 +77,25 @@ struct SG_client_request_async {
    SG_client_read_callback_t read_callback;
 };
 
-// structure for synchronous uploads 
+// structure for synchronous uploads
 struct SG_client_request_sync_state {
    struct SG_chunk dataplane_message;
    off_t offset;
 };
 
-// allocate an asynchronous request 
+// allocate an asynchronous request
 // return NULL on OOM
 struct SG_client_request_async* SG_client_request_async_new(void) {
    return SG_CALLOC( struct SG_client_request_async, 1 );
 }
 
 
-// get the user-given state from an async request 
+// get the user-given state from an async request
 void* SG_client_request_async_cls( struct SG_client_request_async* datareq ) {
    return datareq->cls;
 }
 
-// set up an asynchronous request 
+// set up an asynchronous request
 void SG_client_request_async_init( struct SG_client_request_async* req, SG_client_read_callback_t read_callback, size_t maxlen, void* cls ) {
    req->read_callback = read_callback;
    req->cls = cls;
@@ -103,16 +103,16 @@ void SG_client_request_async_init( struct SG_client_request_async* req, SG_clien
 }
 
 
-// default read callback for synchronous requests 
+// default read callback for synchronous requests
 // returns number of bytes copied
 static size_t SG_client_request_sync_read_callback( char* buf, size_t len, size_t nitems, void* cls ) {
-   
+
    struct SG_client_request_async* datareq = (struct SG_client_request_async*)cls;
    struct SG_client_request_sync_state* sync_state = (struct SG_client_request_sync_state*)datareq->cls;
 
    off_t max_copy = MIN( len * nitems, (unsigned)sync_state->dataplane_message.len - (unsigned)sync_state->offset );
    if( max_copy < 0 ) {
-      // overflow 
+      // overflow
       SG_error("%s", "FATAL: overflow in copy\n");
       exit(1);
    }
@@ -128,7 +128,7 @@ static size_t SG_client_request_sync_read_callback( char* buf, size_t len, size_
    return max_copy;
 }
 
-// make an async request closure for a RAM chunk 
+// make an async request closure for a RAM chunk
 // the chunk will be ref'ed, not copied
 static struct SG_client_request_async* SG_client_request_sync( struct SG_chunk* dataplane_message ) {
    struct SG_client_request_async* req = SG_client_request_async_new();
@@ -159,7 +159,7 @@ static struct SG_client_request_async* SG_client_request_sync( struct SG_chunk* 
 }
 
 
-// free an async request used for synchronous communication 
+// free an async request used for synchronous communication
 // the dataplane message chunk will not be touched.
 static void SG_client_request_sync_free( struct SG_client_request_async* datareq ) {
    if( datareq->cls != NULL ) {
@@ -170,14 +170,14 @@ static void SG_client_request_sync_free( struct SG_client_request_async* datareq
 }
 
 
-// free a request cls.  always succeeds 
+// free a request cls.  always succeeds
 void SG_client_request_cls_free( struct SG_client_request_cls* cls ) {
-   
+
    SG_safe_free( cls->url );
    SG_safe_free( cls->serialized_message );
-   
+
    if( cls->form_begin != NULL ) {
-      
+
       curl_formfree( cls->form_begin );
       cls->form_begin = NULL;
    }
@@ -188,7 +188,7 @@ void SG_client_request_cls_free( struct SG_client_request_cls* cls ) {
 // return 0 on success
 // return -EPERM if the data is invalid
 // return -EINVAL if the args are invalid
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data* reqdat, uint64_t coordinator_gateway_id, struct SG_chunk* serialized_manifest_chunk, struct SG_manifest* manifest ) {
 
    int rc = 0;
@@ -201,11 +201,11 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
 
    memset( &manifest_chunk, 0, sizeof(struct SG_chunk));
 
-   // deserialize 
+   // deserialize
    rc = SG_gateway_impl_deserialize( gateway, reqdat, serialized_manifest_chunk, &manifest_chunk );
    if( rc != 0 ) {
 
-      // error 
+      // error
       SG_error("SG_gateway_impl_deserialize rc = %d\n", rc );
       return rc;
    }
@@ -213,12 +213,12 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
    manifest_str = manifest_chunk.data;
    manifest_strlen = manifest_chunk.len;
 
-   // parse 
+   // parse
    rc = md_parse< SG_messages::Manifest >( &mmsg, manifest_str, manifest_strlen );
-   
+
    if( rc != 0 ) {
-      
-      // failed to parse 
+
+      // failed to parse
       SG_error("md_parse rc = %d\n", rc );
       SG_chunk_free( &manifest_chunk );
       if( rc != -ENOMEM ) {
@@ -226,11 +226,11 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
       }
       return rc;
    }
-   
+
    // is this message from that gateway?
    rc = ms_client_verify_gateway_message< SG_messages::Manifest >( ms, volume_id, coordinator_gateway_id, &mmsg );
    if( rc != 0 ) {
-      
+
       SG_error("ms_client_verify_gateway_message(from=%" PRIu64 ") rc = %d\n", coordinator_gateway_id, rc );
       SG_chunk_free( &manifest_chunk );
       if( rc != -ENOMEM ) {
@@ -238,12 +238,12 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
       }
       return rc;
    }
-   
-   // deserialize 
+
+   // deserialize
    rc = SG_manifest_load_from_protobuf( manifest, &mmsg );
    SG_chunk_free( &manifest_chunk );
    if( rc != 0 ) {
-      
+
       SG_error("SG_manifest_load_from_protobuf rc = %d\n", rc );
       rc = -EPERM;
    }
@@ -255,8 +255,8 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
 // return 0 on success
 // return -ENOMEM on OOM
 // return -EAGAIN if the remote gateway is not known to us (i.e. we can't make a manifest url, and we should reload)
-// return -EINVAL if we failed to parse the message 
-// return -ETIMEDOUT if the request timed out 
+// return -EINVAL if we failed to parse the message
+// return -ETIMEDOUT if the request timed out
 // return -EREMOTEIO if the request failed with HTTP 500 or higher
 // return -ENOENT on HTTP 404
 // return -EPERM on HTTP 400
@@ -265,25 +265,25 @@ int SG_client_parse_manifest( struct SG_gateway* gateway, struct SG_request_data
 // return -EPROTO on any other HTTP 400-level error
 // return -errno on socket- and recv-related errors
 static int SG_client_get_manifest_curl( struct SG_gateway* gateway, struct SG_request_data* reqdat, CURL* curl, uint64_t coordinator_gateway_id, struct SG_manifest* manifest ) {
-   
+
    int rc = 0;
    char* serialized_manifest = NULL;
    off_t serialized_manifest_len = 0;
-   
+
    SG_messages::Manifest mmsg;
    struct SG_chunk serialized_manifest_chunk;
    int cache_rc = 0;
 
    memset( &serialized_manifest_chunk, 0, sizeof(struct SG_chunk) );
-   
+
    // download!
    rc = md_download_run( curl, SG_MAX_MANIFEST_LEN, &serialized_manifest, &serialized_manifest_len );
    if( rc != 0 ) {
-      
-      // download failed 
+
+      // download failed
       SG_error("md_download_run rc = %d\n", rc );
-      
-      // translate HTTP-400-level errors 
+
+      // translate HTTP-400-level errors
       if( rc == -404 ) {
          rc = -ENOENT;
       }
@@ -299,13 +299,13 @@ static int SG_client_get_manifest_curl( struct SG_gateway* gateway, struct SG_re
       else if( rc >= -499 && rc <= -400 ) {
          rc = -EPROTO;
       }
-      
+
       return rc;
    }
-   
+
    serialized_manifest_chunk.data = serialized_manifest;
    serialized_manifest_chunk.len = serialized_manifest_len;
-  
+
    rc = SG_client_parse_manifest( gateway, reqdat, coordinator_gateway_id, &serialized_manifest_chunk, manifest );
    if( rc != 0 ) {
       SG_error("SG_client_parse_manifest(from=%" PRIu64 ") rc = %d\n", coordinator_gateway_id, rc );
@@ -313,7 +313,7 @@ static int SG_client_get_manifest_curl( struct SG_gateway* gateway, struct SG_re
       memset( &serialized_manifest_chunk, 0, sizeof(struct SG_chunk));
       return rc;
    }
-   
+
    // gift the raw data we received to the cache
    cache_rc = SG_gateway_cached_manifest_put_raw_async( gateway, reqdat, &serialized_manifest_chunk, SG_CACHE_FLAG_DETACHED | SG_CACHE_FLAG_UNSHARED, NULL );
    if( cache_rc != 0 ) {
@@ -329,231 +329,231 @@ static int SG_client_get_manifest_curl( struct SG_gateway* gateway, struct SG_re
 
 
 // download a manifest (from the caches) from remote_gateway_id; verify it came from coordinator_gateway_id; parse it
-// return 0 on success, and popuilate *manifest 
+// return 0 on success, and popuilate *manifest
 // return -ENOMEM on OOM
 // return -EINVAL if reqdat doesn't refer to a manifest
-// return -EINVAL if we failed to parse the message 
+// return -EINVAL if we failed to parse the message
 // return -EBADMSG if the manifest timestamp, volume, file version, or file ID doesn't match the received manifest
 // return -EAGAIN if the remote gateway is not known to us (i.e. we can't make a manifest url, and we should reload)
-// return -ETIMEDOUT if the request timed out 
+// return -ETIMEDOUT if the request timed out
 // return -EREMOTEIO if the request failed with HTTP 500 or higher
 // return -EPROTO on HTTP 400-level message
 // return -errno on socket- and recv-related errors
 // return non-zero if the gateway's driver method to connect to the cache fails
 int SG_client_get_manifest( struct SG_gateway* gateway, struct SG_request_data* reqdat, uint64_t coordinator_gateway_id, uint64_t remote_gateway_id, struct SG_manifest* manifest ) {
-   
+
    int rc = 0;
    char* manifest_url = NULL;
    CURL* curl = NULL;
    struct ms_client* ms = SG_gateway_ms( gateway );
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
-   
+
    uint64_t volume_id = ms_client_get_volume_id( ms );
-   
+
    uint64_t remote_gateway_type = 0;
-   
+
    SG_messages::Manifest mmsg;
-   
-   // sanity check 
+
+   // sanity check
    if( !SG_request_is_manifest( reqdat ) ) {
-      
+
       return -EINVAL;
    }
-   
+
    // sanity check--do we know of this gateway?
    remote_gateway_type = ms_client_get_gateway_type( ms, remote_gateway_id );
    if( remote_gateway_type == SG_INVALID_GATEWAY_ID ) {
-      
-      // not present 
+
+      // not present
       SG_error("ms_client_get_gateway_type( %" PRIu64 " ) rc = -1\n", remote_gateway_id );
-      
+
       // caller can reload and try again
       return -EAGAIN;
    }
-   
-   // generate URL 
+
+   // generate URL
    rc = md_url_make_manifest_url( ms, reqdat->fs_path, remote_gateway_id, reqdat->file_id, reqdat->file_version, &reqdat->manifest_timestamp, &manifest_url );
    if( rc != 0 ) {
-      
+
       if( rc == -ENOENT ) {
-         
-         // gateway not found. 
-         // caller can try to reload the cert bundle, if desired 
+
+         // gateway not found.
+         // caller can try to reload the cert bundle, if desired
          rc = -EAGAIN;
       }
-      
+
       return rc;
    }
-   
-   // TODO: connection pool 
+
+   // TODO: connection pool
    curl = curl_easy_init();
-   
+
    if( curl == NULL ) {
-      
+
       SG_safe_free( manifest_url );
       return -ENOMEM;
    }
-   
+
    // set CURL url, just in case
    md_init_curl_handle( conf, curl, manifest_url, conf->connect_timeout );
-   
-   // connect to caches 
+
+   // connect to caches
    rc = SG_gateway_impl_connect_cache( gateway, curl, manifest_url );
    if( rc == -ENOSYS ) {
       rc = 0;
    }
    else if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("SG_gateway_impl_connect_cache('%s') rc = %d\n", manifest_url, rc );
-      
+
       curl_easy_cleanup( curl );
       SG_safe_free( manifest_url );
-      
+
       return rc;
    }
-   
+
    rc = SG_client_get_manifest_curl( gateway, reqdat, curl, coordinator_gateway_id, manifest );
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("SG_client_get_manifest_curl('%s') (wrote by %" PRIu64 ") rc = %d\n", manifest_url, coordinator_gateway_id, rc );
-      
+
       curl_easy_cleanup( curl );
       SG_safe_free( manifest_url );
-   
+
       return rc;
    }
-   
+
    // is it the one we requested?
    if( SG_manifest_get_volume_id( manifest ) != volume_id ||
-       SG_manifest_get_file_id( manifest ) != reqdat->file_id || 
-       SG_manifest_get_file_version( manifest ) != reqdat->file_version || 
+       SG_manifest_get_file_id( manifest ) != reqdat->file_id ||
+       SG_manifest_get_file_version( manifest ) != reqdat->file_version ||
        SG_manifest_get_coordinator( manifest ) != coordinator_gateway_id ||
        SG_manifest_get_modtime_sec( manifest ) != reqdat->manifest_timestamp.tv_sec ||
        SG_manifest_get_modtime_nsec( manifest ) != reqdat->manifest_timestamp.tv_nsec ) {
-      
-      // failed 
+
+      // failed
       SG_error("manifest '%s' mismatch: expected volume=%" PRIu64 " gateway=%" PRIu64 " file=%" PRIX64 ".%" PRId64 " timestamp=%ld.%ld, but got volume=%" PRIu64 " file=%" PRIX64 ".%" PRId64 " timestamp=%ld.%ld\n",
                reqdat->fs_path, volume_id, coordinator_gateway_id, reqdat->file_id, reqdat->file_version, reqdat->manifest_timestamp.tv_sec, reqdat->manifest_timestamp.tv_nsec,
                SG_manifest_get_volume_id( manifest ), SG_manifest_get_file_id( manifest ), SG_manifest_get_file_version( manifest ), (long)SG_manifest_get_modtime_sec( manifest ), (long)SG_manifest_get_modtime_nsec( manifest ) );
-      
+
       curl_easy_cleanup( curl );
       SG_safe_free( manifest_url );
-   
+
       return -EBADMSG;
    }
-   
+
    curl_easy_cleanup( curl );
    SG_safe_free( manifest_url );
-   
+
    return rc;
 }
 
 
-// set up and start a download context used for transferring data asynchronously 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// set up and start a download context used for transferring data asynchronously
+// return 0 on success
+// return -ENOMEM on OOM
 int SG_client_download_async_start( struct SG_gateway* gateway, struct md_download_loop* dlloop, struct md_download_context* dlctx, uint64_t chunk_id, char* url, off_t max_size, void* cls, void (*free_cls)(void*) ) {
-   
+
    int rc = 0;
    CURL* curl = NULL;
    uint64_t block_size = 0;
-   
+
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
    struct ms_client* ms = SG_gateway_ms( gateway );
    block_size = ms_client_get_volume_blocksize( ms );
-   
+
    struct SG_client_request_cls* reqcls = SG_CALLOC( struct SG_client_request_cls, 1 );
    if( reqcls == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
-   // TODO: connection pool 
+
+   // TODO: connection pool
    curl = curl_easy_init();
    if( curl == NULL ) {
-      
+
       SG_safe_free( reqcls );
       return -ENOMEM;
    }
-   
+
    md_init_curl_handle( conf, curl, url, conf->connect_timeout );
-   
-   // connect to caches 
+
+   // connect to caches
    rc = SG_gateway_impl_connect_cache( gateway, curl, url );
    if( rc == -ENOSYS ) {
       rc = 0;
    }
    else if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("SG_gateway_impl_connect_cache('%s') rc = %d\n", url, rc );
-      
+
       curl_easy_cleanup( curl );
       SG_safe_free( reqcls );
-      
+
       return rc;
    }
-   
-   // set up download state 
+
+   // set up download state
    reqcls->url = url;
    reqcls->chunk_id = chunk_id;
    reqcls->cls = cls;
    reqcls->free_cls = free_cls;
-   
-   // set up 
+
+   // set up
    rc = md_download_context_init( dlctx, curl, block_size * SG_MAX_BLOCK_LEN_MULTIPLIER, reqcls );
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("md_download_init('%s') rc = %d\n", url, rc );
       curl_easy_cleanup( curl );
       SG_safe_free( reqcls );
-      
+
       return rc;
    }
-   
+
    // reference it, to keep it around despite the fate of the download loop struct
    md_download_context_ref( dlctx );
-   
-   // watch it 
+
+   // watch it
    rc = md_download_loop_watch( dlloop, dlctx );
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("md_download_loop_watch rc = %d\n", rc );
-      
+
       md_download_context_free( dlctx, NULL );
       curl_easy_cleanup( curl );
-      
+
       SG_safe_free( reqcls );
-      
+
       return rc;
    }
-   
-   // start 
+
+   // start
    rc = md_download_context_start( gateway->dl, dlctx );
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("md_download_context_start('%s') rc = %d\n", url, rc );
-      
+
       md_download_context_free( dlctx, NULL );
-      
+
       // TODO: connection pool
       curl_easy_cleanup( curl );
       SG_safe_free( reqcls );
-      
+
       return rc;
    }
-   
+
    // started!
    return 0;
 }
 
 
-// clean up a request data context 
+// clean up a request data context
 void SG_client_request_cls_cleanup_and_free( struct SG_client_request_cls* reqcls ) {
 
    if( reqcls != NULL ) {
@@ -568,122 +568,122 @@ void SG_client_request_cls_cleanup_and_free( struct SG_client_request_cls* reqcl
 }
 
 // clean up a download context used for transfering data asynchronously, including the associated state
-// TODO: release the curl handle into the connection pool 
+// TODO: release the curl handle into the connection pool
 void SG_client_download_async_cleanup( struct md_download_context* dlctx ) {
-   
+
    CURL* curl = NULL;
-   
+
    struct SG_client_request_cls* reqcls = (struct SG_client_request_cls*)md_download_context_get_cls( dlctx );
-   
+
    // clean up
    int free_rc = md_download_context_unref( dlctx );
    if( free_rc > 0 ) {
-      
+
       SG_debug("Will free download context %p\n", dlctx );
       md_download_context_free( dlctx, &curl );
-      
+
       if( curl != NULL ) {
-         // TODO: connection pool 
+         // TODO: connection pool
          curl_easy_cleanup( curl );
       }
-   
+
       // SG_client_request_cls_cleanup_and_free( reqcls );
    }
-   
+
    return;
 }
 
 
 // clean up the state for each download in an (aborted) download loop
 // NOTE: only use this in conjunction with SG_client_download_async_start
-// always succeeds 
+// always succeeds
 void SG_client_download_async_cleanup_loop( struct md_download_loop* dlloop ) {
 
    struct md_download_context* dlctx = NULL;
    int i = 0;
-   
+
    // free all ms_client_get_metadata_context
    for( dlctx = md_download_loop_next_initialized( dlloop, &i ); dlctx != NULL; dlctx = md_download_loop_next_initialized( dlloop, &i ) ) {
-      
+
       if( dlctx == NULL ) {
          break;
       }
-      
+
       SG_client_download_async_cleanup( dlctx );
    }
 }
 
 
 // wait for a download to finish, get the buffer, and free the download handle
-// return 0 on success 
+// return 0 on success
 // return -ENODATA if the download did not suceeed with HTTP 200
-// return -errno if we failed to wait for the download, somehow 
+// return -errno if we failed to wait for the download, somehow
 // return -ENOMEM on OOM
 int SG_client_download_async_wait( struct md_download_context* dlctx, uint64_t* chunk_id, char** chunk_buf, off_t* chunk_len, void** cls ) {
-   
+
    int rc = 0;
    int http_status = 0;
 
    SG_debug("Wait on dlctx %p\n", dlctx);
    struct SG_client_request_cls* reqcls = (struct SG_client_request_cls*)md_download_context_get_cls( dlctx );
-   
+
    md_download_context_set_cls( dlctx, NULL );
 
    if( reqcls == NULL ) {
-      // already been waited on 
+      // already been waited on
       SG_error("Download %p already waited on\n", dlctx);
       return -EINVAL;
    }
-   
+
    // are we ready?
    if( !md_download_context_finalized( dlctx ) ) {
-      
+
       // wait for it...
       rc = md_download_context_wait( dlctx, -1 );
       if( rc != 0 ) {
-         
+
          SG_error("md_download_context_wait( %p ) rc = %d\n", dlctx, rc );
-         
+
          SG_client_download_async_cleanup( dlctx );
          SG_client_request_cls_cleanup_and_free( reqcls );
          return rc;
       }
    }
-   
+
    // do we even have data?
    if( !md_download_context_succeeded( dlctx, 200 ) ) {
-      
+
       http_status = md_download_context_get_http_status( dlctx );
-      
+
       SG_error("download %p finished with HTTP status %d\n", dlctx, http_status );
-      
+
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return -ENODATA;
    }
-   
-   // get the chunk from the download context 
+
+   // get the chunk from the download context
    rc = md_download_context_get_buffer( dlctx, chunk_buf, chunk_len );
    if( rc != 0 ) {
-      
-      // OOM 
+
+      // OOM
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return rc;
    }
-   
+
    // get the chunk ID from the download's driver
    *chunk_id = reqcls->chunk_id;
-   
+
    if( cls != NULL ) {
       *cls = reqcls->cls;
       reqcls->cls = NULL;
    }
-   
+
    // done!
    SG_client_download_async_cleanup( dlctx );
    SG_client_request_cls_cleanup_and_free( reqcls );
-   
+
    return rc;
 }
 
@@ -700,62 +700,62 @@ static void SG_client_get_block_async_cleanup( void* cls ) {
 }
 
 
-// begin downloading a block 
+// begin downloading a block
 // NOTE: reqdat must be a block request
 // return 0 on success, and set up *dlctx to refer to the downloading context
 // return -ENOMEM if OOM
 // return -ENOMEM if reqdat isn't a block request
-// return -ENOENT if the remote gateway cannot be looked up 
+// return -ENOENT if the remote gateway cannot be looked up
 int SG_client_get_block_async( struct SG_gateway* gateway, struct SG_request_data* reqdat, uint64_t remote_gateway_id, struct md_download_loop* dlloop, struct md_download_context* dlctx ) {
-   
+
    int rc = 0;
    char* block_url = NULL;
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
-   
+
    struct SG_request_data* reqdat_dup = NULL;
-   
-   // sanity check 
+
+   // sanity check
    if( !SG_request_is_block( reqdat ) ) {
-      
+
       return -EINVAL;
    }
-   
-   // get block url 
+
+   // get block url
    rc = md_url_make_block_url( ms, reqdat->fs_path, remote_gateway_id, reqdat->file_id, reqdat->file_version, reqdat->block_id, reqdat->block_version, &block_url );
    if( rc != 0 ) {
-      
-      // failed to create block url 
+
+      // failed to create block url
       return rc;
    }
-   
+
    // duplicate request data--we'll need it for SG_client_get_block_finish
    reqdat_dup = SG_CALLOC( struct SG_request_data, 1 );
    if( reqdat_dup == NULL ) {
-      
+
       SG_safe_free( block_url );
       return -ENOMEM;
    }
-   
+
    rc = SG_request_data_dup( reqdat_dup, reqdat );
    if( rc != 0 ) {
-      
+
       SG_safe_free( block_url );
       SG_safe_free( reqdat_dup );
       return rc;
    }
-   
+
    // GOGOO!
    rc = SG_client_download_async_start( gateway, dlloop, dlctx, reqdat->block_id, block_url, block_size * SG_MAX_BLOCK_LEN_MULTIPLIER, reqdat_dup, SG_client_get_block_async_cleanup );
    if( rc != 0 ) {
-      
+
       SG_error("SG_client_download_async_start('%s') rc = %d\n", block_url, rc );
       SG_safe_free( block_url );
       return rc;
    }
-   
+
    return rc;
 }
 
@@ -766,29 +766,29 @@ static void SG_client_log_hash_mismatch( unsigned char* expected_block_hash, uns
 
    char* expected_block_hash_str = NULL;
    char* actual_block_hash_str = NULL;
-   
+
    bool logged = false;
 
    expected_block_hash_str = md_data_printable( expected_block_hash, SG_BLOCK_HASH_LEN );
    actual_block_hash_str = md_data_printable( block_hash, SG_BLOCK_HASH_LEN );
-   
+
    if( expected_block_hash_str != NULL && actual_block_hash_str != NULL ) {
-      
+
       SG_error("Hash mismatch: expected '%s', got '%s'\n", expected_block_hash_str, actual_block_hash_str );
-      
+
       logged = true;
    }
-   
+
    SG_safe_free( expected_block_hash_str );
    SG_safe_free( actual_block_hash_str );
-   
+
    if( !logged ) {
       SG_error("%s", "Hash mismatch: check failed\n" );
    }
 }
 
 
-// log a block hash mismatch from a manifest 
+// log a block hash mismatch from a manifest
 // always succeeds
 static void SG_client_get_block_log_hash_mismatch( struct SG_manifest* manifest, uint64_t block_id, unsigned char* block_hash ) {
 
@@ -796,24 +796,24 @@ static void SG_client_get_block_log_hash_mismatch( struct SG_manifest* manifest,
    unsigned char* expected_block_hash = NULL;
    size_t expected_block_hash_len = 0;
    int rc = 0;
-   
+
    rc = SG_manifest_get_block_hash( manifest, block_id, &expected_block_hash, &expected_block_hash_len );
    if( rc == 0 ) {
-      
+
       SG_client_log_hash_mismatch( expected_block_hash, block_hash );
       SG_safe_free( expected_block_hash );
    }
    else {
       SG_error("SG_manifest_block_hash_eq(%" PRIu64 "): check failed\n", block_id );
    }
-   
+
    return;
 }
 
 
-// sign a serialized block: prepend a serialized signed block header 
+// sign a serialized block: prepend a serialized signed block header
 // return 0 on success, and set *signed_chunk
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EINVAL if reqdat is not for a block
 // return -EPERM on signature failure
 int SG_client_block_sign( struct SG_gateway* gateway, struct SG_request_data* reqdat, struct SG_chunk* block_data, struct SG_chunk* signed_block_data ) {
@@ -822,7 +822,7 @@ int SG_client_block_sign( struct SG_gateway* gateway, struct SG_request_data* re
    SG_messages::SignedBlockHeader blkhdr;
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t volume_id = ms_client_get_volume_id( ms );
-   
+
    unsigned char block_hash[SHA256_DIGEST_LENGTH];
    char* hdr_buf = NULL;
    size_t hdr_buf_len = 0;
@@ -849,13 +849,13 @@ int SG_client_block_sign( struct SG_gateway* gateway, struct SG_request_data* re
       return -ENOMEM;
    }
 
-   rc = md_sign< SG_messages::SignedBlockHeader >( SG_gateway_private_key( gateway ), &blkhdr ); 
+   rc = md_sign< SG_messages::SignedBlockHeader >( SG_gateway_private_key( gateway ), &blkhdr );
    if( rc != 0 ) {
       SG_error("md_sign rc = %d\n", rc );
       return -EPERM;
    }
 
-   // re-pack 
+   // re-pack
    rc = md_serialize< SG_messages::SignedBlockHeader >( &blkhdr, &hdr_buf, &hdr_buf_len );
    if( rc != 0 ) {
       SG_error("md_serialize rc = %d\n", rc );
@@ -904,7 +904,7 @@ int SG_client_block_verify( struct SG_gateway* gateway, uint64_t coordinator_id,
    uint64_t data_len = 0;
 
    if( (unsigned)signed_block->len < sizeof(uint32_t) ) {
-      // can't even have the header length 
+      // can't even have the header length
       return -EBADMSG;
    }
 
@@ -912,7 +912,7 @@ int SG_client_block_verify( struct SG_gateway* gateway, uint64_t coordinator_id,
    hdr_len = ntohl( hdr_len );
 
    if( (unsigned)signed_block->len < sizeof(uint32_t) + hdr_len ) {
-      // can't have fit the header 
+      // can't have fit the header
       SG_debug("Invalid header length %zu + %u\n", sizeof(uint32_t), hdr_len);
       return -EBADMSG;
    }
@@ -920,19 +920,19 @@ int SG_client_block_verify( struct SG_gateway* gateway, uint64_t coordinator_id,
    // load header
    rc = md_parse< SG_messages::SignedBlockHeader >( &blkhdr, signed_block->data + sizeof(uint32_t), hdr_len );
    if( rc != 0 ) {
-      // bad message 
+      // bad message
       SG_debug("Unparseable data (offset %zu, length %u)\n", sizeof(uint32_t), hdr_len );
       return -EBADMSG;
    }
 
-   // must be the coordinator 
+   // must be the coordinator
    if( coordinator_id != blkhdr.gateway_id() ) {
       // invalid message
       SG_debug("Coordinator mismatch: expected %" PRIu64 ", got %" PRIu64 "\n", coordinator_id, blkhdr.gateway_id());
       return -EPERM;
    }
 
-   // verify header 
+   // verify header
    ms_client_config_rlock( ms );
 
    cert = ms_client_get_gateway_cert( ms, blkhdr.gateway_id() );
@@ -960,14 +960,14 @@ int SG_client_block_verify( struct SG_gateway* gateway, uint64_t coordinator_id,
       return -EPERM;
    }
 
-   // verify block 
+   // verify block
    data_offset = sizeof(uint32_t) + hdr_len;
    data_len = signed_block->len - data_offset;
    sha256_hash_buf( signed_block->data + data_offset, data_len, block_hash );
 
    rc = memcmp( block_hash, (unsigned char*)blkhdr.block_hash().data(), SHA256_DIGEST_LENGTH );
    if( rc != 0 ) {
-      // hash mismatch 
+      // hash mismatch
       SG_client_log_hash_mismatch( (unsigned char*)blkhdr.block_hash().data(), block_hash );
       return -EPERM;
    }
@@ -982,14 +982,14 @@ int SG_client_block_verify( struct SG_gateway* gateway, uint64_t coordinator_id,
 // * otherwise, if the block has a signed block header, use the signed block header
 // authentication fails if there is a hash mismatch, signature mismatch, or missing data.
 // return 0 on success
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EPERM if the data could not be authenticated (block not present, hash mismatch, etc.)
 static int SG_client_block_authenticate( struct SG_gateway* gateway, struct SG_manifest* manifest, uint64_t block_id, struct SG_chunk* block_data, uint64_t* block_data_offset ) {
 
    int rc = 0;
    unsigned char* block_hash = NULL;
 
-   
+
    // block exists?
    if( !SG_manifest_is_block_present( manifest, block_id ) ) {
       return -EPERM;
@@ -1005,56 +1005,56 @@ static int SG_client_block_authenticate( struct SG_gateway* gateway, struct SG_m
       if( rc != 0 ) {
          SG_error("SG_client_block_verify(%" PRIu64 ") rc = %d\n", block_id, rc );
          return rc;
-      
+
       }
    }
    else {
 
-      // have hash 
-      // get the hash 
+      // have hash
+      // get the hash
       block_hash = sha256_hash_data( block_data->data, block_data->len );
       if( block_hash == NULL ) {
-         
-         // OOM 
+
+         // OOM
          return -ENOMEM;
       }
-     
+
       // compare to the hash in the manifest, verifying that it is actually present at the same time.
       rc = SG_manifest_block_hash_eq( manifest, block_id, block_hash, SG_BLOCK_HASH_LEN );
       if( rc < 0 ) {
-         
-         // error 
+
+         // error
          SG_error("SG_manifest_block_hash_eq( %" PRIu64 " ) rc = %d\n", block_id, rc );
-         
+
          SG_safe_free( block_hash );
          return rc;
       }
       else if( rc == 0 ) {
-         
-         // mismatch 
+
+         // mismatch
          SG_client_get_block_log_hash_mismatch( manifest, block_id, block_hash );
          SG_safe_free( block_hash );
-         
+
          return -EPERM;
       }
-   
+
       *block_data_offset = 0;
       SG_safe_free( block_hash );
    }
 
    return 0;
-} 
+}
 
-// parse a block from a download context, and use the manifest to verify it's integrity 
+// parse a block from a download context, and use the manifest to verify it's integrity
 // if the block is still downloading, wait for it to finish (indefinitely). Otherwise, load right away.
 // deserialize the block once we have it.
-// return 0 on success, and populate *block with its contents 
-// return -ENOMEM on OOM 
+// return 0 on success, and populate *block with its contents
+// return -ENOMEM on OOM
 // return -EINVAL if the request is not for a block
 // return -ENODATA if the download context did not successfully finish
 // return -EBADMSG if the block's authenticity could not be verified with the manifest
 int SG_client_get_block_finish( struct SG_gateway* gateway, struct SG_manifest* manifest, struct md_download_context* dlctx, uint64_t* block_id, struct SG_chunk* deserialized_block ) {
-   
+
    int rc = 0;
    char* block_buf = NULL;
    off_t block_len = 0;
@@ -1064,21 +1064,21 @@ int SG_client_get_block_finish( struct SG_gateway* gateway, struct SG_manifest* 
    struct SG_chunk block_chunk;
    struct SG_chunk block_data_chunk;
    char* data_chunk = NULL;
-   
+
    // get the data; recover the original reqdat
    rc = SG_client_download_async_wait( dlctx, block_id, &block_buf, &block_len, (void**)&reqdat );
    if( rc != 0 ) {
-      
+
       SG_error("SG_client_download_async_wait( %p ) rc = %d\n", dlctx, rc );
       return rc;
    }
- 
+
    SG_debug("Finished block %" PRIX64 ".%" PRId64 "[%" PRIu64 "]\n", reqdat->file_id, reqdat->file_version, *block_id );
 
    block_chunk.data = block_buf;
    block_chunk.len = block_len;
 
-   // authenticate the data 
+   // authenticate the data
    rc = SG_client_block_authenticate( gateway, manifest, *block_id, &block_chunk, &block_data_offset );
    if( rc < 0 ) {
       if( rc == -EPERM ) {
@@ -1114,8 +1114,8 @@ int SG_client_get_block_finish( struct SG_gateway* gateway, struct SG_manifest* 
    rc = SG_gateway_impl_deserialize( gateway, reqdat, &block_data_chunk, deserialized_block );
 
    if( rc == 0 ) {
-    
-      // gift to cache 
+
+      // gift to cache
       int cache_rc = SG_gateway_cached_block_put_raw_async( gateway, reqdat, &block_data_chunk, SG_CACHE_FLAG_DETACHED | SG_CACHE_FLAG_UNSHARED, NULL );
       if( cache_rc != 0 ) {
          SG_warn("SG_gateway_cached_block_put_raw_async rc = %d\n", rc );
@@ -1137,20 +1137,20 @@ int SG_client_get_block_finish( struct SG_gateway* gateway, struct SG_manifest* 
 }
 
 
-// get an xattr by name 
+// get an xattr by name
 // return 0 on success, and set *xattr_value and *xattr_value_len
-// return -ENOMEM on OOM 
 // return -ENOMEM on OOM
-// return -ETIMEDOUT if the tranfser could not complete in time 
+// return -ENOMEM on OOM
+// return -ETIMEDOUT if the tranfser could not complete in time
 // return -EAGAIN if we were signaled to retry the request, or if we don't know about gateway_id
-// return -EREMOTEIO if the HTTP error is >= 500 
+// return -EREMOTEIO if the HTTP error is >= 500
 // return -ENOATTR on HTTP 404
 // return -EACCES on HTTP 401 or 403
 // return -EPERM on HTTP 400
 // return -ESTALE on HTTP 410
 // return -EPROTO for any other HTTP 400-level error
 int SG_client_getxattr( struct SG_gateway* gateway, uint64_t gateway_id, char const* fs_path, uint64_t file_id, int64_t file_version, char const* xattr_name, uint64_t xattr_nonce, char** xattr_value, size_t* xattr_len ) {
-    
+
     int rc = 0;
     char* xattr_url = NULL;
     struct ms_client* ms = SG_gateway_ms( gateway );
@@ -1158,43 +1158,43 @@ int SG_client_getxattr( struct SG_gateway* gateway, uint64_t gateway_id, char co
     CURL* curl = NULL;
     SG_messages::Reply reply;
     struct ms_gateway_cert* gateway_cert = NULL;
-    
+
     char* buf = NULL;
     off_t len = 0;
-    
+
     ms_client_config_rlock( ms );
-    
+
     gateway_cert = ms_client_get_gateway_cert( ms, gateway_id );
-    
+
     ms_client_config_unlock( ms );
-    
+
     // gateway exists?
     if( gateway_cert == NULL ) {
         return -EAGAIN;
     }
-    
+
     gateway_cert = NULL;
-    
-    // TODO: connection pool 
+
+    // TODO: connection pool
     curl = curl_easy_init();
     if( curl == NULL ) {
         return -ENOMEM;
     }
-    
+
     rc = md_url_make_getxattr_url( ms, fs_path, gateway_id, file_id, file_version, xattr_name, xattr_nonce, &xattr_url );
     if( rc != 0 ) {
-        
+
         curl_easy_cleanup( curl );
         return rc;
     }
-    
+
     md_init_curl_handle( conf, curl, xattr_url, conf->connect_timeout );
-    
+
     rc = md_download_run( curl, SG_MAX_XATTR_LEN, &buf, &len );
     curl_easy_cleanup( curl );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("md_download_run('%s') rc = %d\n", xattr_url, rc );
         SG_safe_free( xattr_url );
 
@@ -1214,76 +1214,76 @@ int SG_client_getxattr( struct SG_gateway* gateway, uint64_t gateway_id, char co
         else if( rc >= -499 && rc <= -400 ) {
             rc = -EPROTO;
         }
-        
+
         return rc;
     }
-    
-    // parse reply 
+
+    // parse reply
     rc = md_parse< SG_messages::Reply >( &reply, buf, len );
     SG_safe_free( buf );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("md_parse('%s') rc = %d\n", xattr_url, rc );
         SG_safe_free( xattr_url );
         return rc;
     }
-    
+
     SG_safe_free( xattr_url );
-    
+
     ms_client_config_rlock( ms );
-    
+
     gateway_cert = ms_client_get_gateway_cert( ms, gateway_id );
     if( gateway_cert == NULL ) {
-        
+
         ms_client_config_unlock( ms );
         return -EAGAIN;
     }
-    
-    // verify reply 
+
+    // verify reply
     rc = md_verify< SG_messages::Reply >( ms_client_gateway_pubkey( gateway_cert ), &reply );
     ms_client_config_unlock( ms );
-    
+
     if( rc != 0 ) {
-        
+
         // invalid reply
         return rc;
     }
-    
-    // validate reply 
+
+    // validate reply
     if( !reply.has_xattr_value() ) {
-        
-        // invalid reply 
+
+        // invalid reply
         return rc;
     }
-    
+
     *xattr_value = SG_strdup_or_null( reply.xattr_value().c_str() );
     if( *xattr_value == NULL ) {
-        
-        // OOM 
+
+        // OOM
         return -ENOMEM;
     }
-    
-    
+
+
     *xattr_len = reply.xattr_value().size();
     return 0;
 }
 
 
-// get a list of xattrs by name 
+// get a list of xattrs by name
 // return 0 on success, and set *xattr_value and *xattr_value_len
-// return -ENOMEM on OOM 
 // return -ENOMEM on OOM
-// return -ETIMEDOUT if the tranfser could not complete in time 
-// return -EAGAIN if we were signaled to retry the request 
+// return -ENOMEM on OOM
+// return -ETIMEDOUT if the tranfser could not complete in time
+// return -EAGAIN if we were signaled to retry the request
 // return -EREMOTEIO if the HTTP error is >= 500
 // return -EPERM on HTTP 400
-// return -EACCES if the HTTP error is 401 or 403 
+// return -EACCES if the HTTP error is 401 or 403
 // return _ENOATTR on HTTP 404
 // return -ESTALE on HTTP 410
 // return -EPROTO for any other HTTP 400-level error
 int SG_client_listxattrs( struct SG_gateway* gateway, uint64_t gateway_id, char const* fs_path, uint64_t file_id, int64_t file_version, uint64_t xattr_nonce, char** xattr_list, size_t* xattr_list_len ) {
-    
+
     int rc = 0;
     char* xattr_url = NULL;
     struct ms_client* ms = SG_gateway_ms( gateway );
@@ -1292,46 +1292,46 @@ int SG_client_listxattrs( struct SG_gateway* gateway, uint64_t gateway_id, char 
     SG_messages::Reply reply;
     struct ms_gateway_cert* gateway_cert = NULL;
     off_t off = 0;
-    
+
     char* buf = NULL;
     off_t len = 0;
-    
+
     ms_client_config_rlock( ms );
-    
+
     gateway_cert = ms_client_get_gateway_cert( ms, gateway_id );
-    
+
     ms_client_config_unlock( ms );
-    
+
     // gateway exists?
     if( gateway_cert == NULL ) {
         return -EAGAIN;
     }
-    
+
     gateway_cert = NULL;
-    
-    // TODO: connection pool 
+
+    // TODO: connection pool
     curl = curl_easy_init();
     if( curl == NULL ) {
         return -ENOMEM;
     }
-    
+
     rc = md_url_make_listxattr_url( ms, fs_path, gateway_id, file_id, file_version, xattr_nonce, &xattr_url );
     if( rc != 0 ) {
-        
+
         curl_easy_cleanup( curl );
         return rc;
     }
-    
+
     md_init_curl_handle( conf, curl, xattr_url, conf->connect_timeout );
-    
+
     rc = md_download_run( curl, SG_MAX_XATTR_LEN, &buf, &len );
     curl_easy_cleanup( curl );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("md_download_run('%s') rc = %d\n", xattr_url, rc );
         SG_safe_free( xattr_url );
-        
+
         if( rc == -400 ) {
             rc = -EPERM;
         }
@@ -1347,173 +1347,173 @@ int SG_client_listxattrs( struct SG_gateway* gateway, uint64_t gateway_id, char 
         else if( rc >= -499 && rc <= -400 ) {
             rc = -EPROTO;
         }
-        
+
         return rc;
     }
-    
-    // parse reply 
+
+    // parse reply
     rc = md_parse< SG_messages::Reply >( &reply, buf, len );
     SG_safe_free( buf );
-    
+
     if( rc != 0 ) {
-        
+
         SG_error("md_parse('%s') rc = %d\n", xattr_url, rc );
         SG_safe_free( xattr_url );
         return rc;
     }
-    
+
     SG_safe_free( xattr_url );
-    
+
     ms_client_config_rlock( ms );
-    
+
     gateway_cert = ms_client_get_gateway_cert( ms, gateway_id );
     if( gateway_cert == NULL ) {
-        
+
         ms_client_config_unlock( ms );
         return -EAGAIN;
     }
-    
-    // verify reply 
+
+    // verify reply
     rc = md_verify< SG_messages::Reply >( ms_client_gateway_pubkey( gateway_cert ), &reply );
     ms_client_config_unlock( ms );
-    
+
     if( rc != 0 ) {
         // invalid reply
         return rc;
     }
-    
+
     if( reply.xattr_names_size() == 0 ) {
-        
-        // no xattrs 
+
+        // no xattrs
         return 0;
     }
-    
+
     // how many bytes?
     *xattr_list_len = 0;
     for( int i = 0; i < reply.xattr_names_size(); i++ ) {
         *xattr_list_len += reply.xattr_names(i).size() + 1;
     }
-    
+
     *xattr_list = SG_CALLOC( char, *xattr_list_len );
     if( *xattr_list == NULL ) {
-        
-        // OOM 
+
+        // OOM
         return -ENOMEM;
     }
-    
+
     for( int i = 0; i < reply.xattr_names_size(); i++ ) {
-        
+
         memcpy( *xattr_list + off, reply.xattr_names(i).c_str(), reply.xattr_names(i).size() );
         off += (reply.xattr_names(i).size() + 1);
     }
-    
+
     SG_debug("%d xattrs, %zu xattr bytes\n", reply.xattr_names_size(), *xattr_list_len);
     return 0;
 }
 
 
-// create a signed block 
+// create a signed block
 // the wire format for which is:
 // [ 0: 4 bytes $HEADER_SIZE ][ 4: $HEADER_SIZE block header ][ $HEADER_SIZE + 4: block data ]
-// return 0 on success 
+// return 0 on success
 // return -ENOMEM on OOM
 // return -EINVAL if reqdat isn't a block request, or if we failed to serialize and sign
 int SG_client_serialize_signed_block( struct SG_gateway* gateway, struct SG_request_data* reqdat, struct SG_chunk* block_in, struct SG_chunk* block_out ) {
-   
+
    int rc = 0;
    unsigned char* block_hash = NULL;
    char* serialized_header = NULL;
    size_t serialized_header_len = 0;
-   
+
    char* block_buf = NULL;
-   
+
    size_t total_length = 0;
    uint32_t header_len_htonl = 0;
-   
-   // sanity check 
+
+   // sanity check
    if( !SG_request_is_block( reqdat ) ) {
-      
+
       return -EINVAL;
    }
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t volume_id = ms_client_get_volume_id( ms );
    uint64_t gateway_id = SG_gateway_id( gateway );
    EVP_PKEY* gateway_private_key = SG_gateway_private_key( gateway );
-   
+
    SG_messages::SignedBlockHeader hdr;
-   
+
    hdr.set_volume_id( volume_id );
    hdr.set_file_id( reqdat->file_id );
    hdr.set_file_version( reqdat->file_version );
    hdr.set_block_id( reqdat->block_id );
    hdr.set_block_version( reqdat->block_version );
    hdr.set_gateway_id( gateway_id );
-   
+
    block_hash = sha256_hash_data( block_in->data, block_in->len );
    if( block_hash == NULL ) {
-      
-      // OOM 
+
+      // OOM
       return -ENOMEM;
    }
-   
+
    try {
-      
+
       hdr.set_block_hash( string( (char*)block_hash, SG_BLOCK_HASH_LEN ) );
    }
    catch( bad_alloc& ba ) {
-      
+
       SG_safe_free( block_hash );
       return -ENOMEM;
    }
-   
+
    SG_safe_free( block_hash );
-   
-   // sign 
+
+   // sign
    rc = md_sign< SG_messages::SignedBlockHeader >( gateway_private_key, &hdr );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
-   // serialize 
+
+   // serialize
    rc = md_serialize< SG_messages::SignedBlockHeader >( &hdr, &serialized_header, &serialized_header_len );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
-   // calculate length and make the buffer 
+
+   // calculate length and make the buffer
    total_length = serialized_header_len + sizeof(uint32_t) + block_in->len;
    block_buf = SG_CALLOC( char, total_length );
    if( block_buf == NULL ) {
-      
-      // OOM 
+
+      // OOM
       SG_safe_free( serialized_header );
       return -ENOMEM;
    }
-   
+
    block_out->len = total_length;
-   
-   // make the buffer 
+
+   // make the buffer
    header_len_htonl = htonl( serialized_header_len );
-   
+
    memcpy( block_buf, &header_len_htonl, sizeof(uint32_t) );
    memcpy( block_buf + sizeof(uint32_t), serialized_header, serialized_header_len );
    memcpy( block_buf + sizeof(uint32_t) + serialized_header_len, block_in->data, block_in->len );
-   
+
    SG_safe_free( serialized_header );
-   
+
    block_out->data = block_buf;
-   
+
    return 0;
 }
 
 
 // parse a signed block.
-// return 0 on success, and put the block data into *block_out 
-// return -EINVAL if the reqdat isn't a block request, or if we failed to deserialize due to a malformatted block_in 
+// return 0 on success, and put the block data into *block_out
+// return -EINVAL if the reqdat isn't a block request, or if we failed to deserialize due to a malformatted block_in
 // return -EBADMSG if the block didn't come from remote_gateway_id (i.e. the id or signature didn't match)
 // return -ENOMEM if OOM
 // return -EAGAIN if we don't know the gateway's public key (yet)
@@ -1521,165 +1521,165 @@ int SG_client_deserialize_signed_block( struct SG_gateway* gateway, struct SG_re
 
    int rc = 0;
    unsigned char* block_hash = NULL;
-   
+
    uint32_t serialized_header_len = 0;
    char* serialized_header = NULL;
    char* serialized_block_buf = NULL;
    char* block_buf = NULL;
 
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    uint64_t block_size = ms_client_get_volume_blocksize( ms );
-   
+
    SG_messages::SignedBlockHeader hdr;
-   
-   // must have at least 4 bytes in the block to get the size 
+
+   // must have at least 4 bytes in the block to get the size
    memcpy( &serialized_header_len, block_in->data, sizeof(uint32_t) );
-   
+
    serialized_header_len = ntohl( serialized_header_len );
-   
-   // header is variable-length but reasonably small...less than 4K for sure 
+
+   // header is variable-length but reasonably small...less than 4K for sure
    if( serialized_header_len >= SG_messages::SignedBlockHeader::MAXIMUM_SIZE ) {
-      
+
       return -EINVAL;
    }
-   
+
    // whole block must fit...
    if( serialized_header_len + sizeof(uint32_t) + block_size >= (unsigned)block_in->len ) {
-      
+
       return -EINVAL;
    }
-   
+
    // safe to load
    serialized_header = block_in->data + sizeof(uint32_t);
-   
+
    // load header
    rc = md_parse< SG_messages::SignedBlockHeader >( &hdr, serialized_header, serialized_header_len );
    if( rc != 0 ) {
-      
+
       SG_error("md_parse rc = %d\n", rc );
       return rc;
    }
-   
+
    // did it come from the expected origin?
    if( hdr.gateway_id() != remote_gateway_id ) {
-      
+
       SG_error("Coordinator mismatch: expected %" PRIu64 ", got %" PRIu64 "\n", hdr.gateway_id(), remote_gateway_id );
       return -EBADMSG;
    }
-   
-   // verify header 
+
+   // verify header
    rc = ms_client_verify_gateway_message< SG_messages::SignedBlockHeader >( ms, hdr.volume_id(), remote_gateway_id, &hdr );
    if( rc != 0 ) {
-      
+
       SG_error("ms_client_verify_gateway_message( from=%" PRIu64 ") rc = %d\n", remote_gateway_id, rc );
-      
+
       if( rc == -EINVAL ) {
-         
-         // hash mismatch 
+
+         // hash mismatch
          rc = -EBADMSG;
       }
-      
+
       return rc;
    }
-   
-   // verify hash length 
+
+   // verify hash length
    if( hdr.block_hash().size() != SG_BLOCK_HASH_LEN ) {
-      
+
       SG_error("SignedBlockHeader hash length = %zu, expected %d\n", hdr.block_hash().size(), SG_BLOCK_HASH_LEN );
       return -EINVAL;
    }
-   
+
    // start of data
    serialized_block_buf = block_in->data + sizeof(uint32_t) + serialized_header_len;
-   
-   // calculate data hash 
+
+   // calculate data hash
    block_hash = sha256_hash_data( serialized_block_buf, block_size );
    if( block_hash == NULL ) {
-      
-      // OOM 
+
+      // OOM
       return -ENOMEM;
    }
-   
-   // verify hash 
+
+   // verify hash
    if( memcmp( block_hash, hdr.block_hash().data(), SG_BLOCK_HASH_LEN ) != 0 ) {
-      
-      // hash mismatch 
+
+      // hash mismatch
       SG_error("%" PRIX64 ".%" PRId64 "[block %" PRIu64 ".%" PRId64 "] (%s): hash mismatch\n", reqdat->file_id, reqdat->file_version, reqdat->block_id, reqdat->block_version, reqdat->fs_path );
       return -EBADMSG;
    }
-   
-   // hash is good; block is authentic 
+
+   // hash is good; block is authentic
    block_out->len = block_size;
    block_buf = SG_CALLOC( char, block_out->len );
    if( block_buf == NULL ) {
-      
-      // OOM 
+
+      // OOM
       return -ENOMEM;
    }
-   
+
    memcpy( block_buf, serialized_block_buf, block_out->len );
    block_out->data = block_buf;
-   
+
    return 0;
 }
 
 
-// set up the common fields of a Request 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// set up the common fields of a Request
+// return 0 on success
+// return -ENOMEM on OOM
 static int SG_client_request_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat ) {
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
+
    uint64_t volume_version = ms_client_volume_version( ms );
    uint64_t cert_version = ms_client_cert_version( ms );
    uint64_t volume_id = ms_client_get_volume_id( ms );
    uint64_t gateway_id = SG_gateway_id( gateway );
    uint64_t user_id = SG_gateway_user_id( gateway );
-   
+
    // sanity check...
    if( reqdat->coordinator_id == SG_INVALID_GATEWAY_ID || reqdat->file_id == SG_INVALID_FILE_ID || reqdat->fs_path == NULL ) {
       SG_error("BUG: missing coordinator (%" PRIu64 "), file_id (%" PRIX64 "), or path (%s)\n", reqdat->coordinator_id, reqdat->file_id, reqdat->fs_path );
       exit(1);
    }
-   
+
    try {
-      
+
       request->set_volume_version( volume_version );
       request->set_cert_version( cert_version );
       request->set_volume_id( volume_id );
       request->set_coordinator_id( reqdat->coordinator_id );
       request->set_file_id( reqdat->file_id );
       request->set_file_version( reqdat->file_version );
-      
+
       request->set_user_id( user_id );
       request->set_src_gateway_id( gateway_id );
       request->set_message_nonce( md_random64() );
-      
+
       request->set_fs_path( string(reqdat->fs_path) );
    }
    catch( bad_alloc& ba ) {
       return -ENOMEM;
    }
-   
+
    return 0;
 }
 
 
-// allocate a write request 
+// allocate a write request
 struct SG_client_WRITE_data* SG_client_WRITE_data_new(void) {
     return SG_CALLOC( struct SG_client_WRITE_data, 1 );
 }
 
-// set up a write reqeust 
+// set up a write reqeust
 int SG_client_WRITE_data_init( struct SG_client_WRITE_data* dat ) {
     memset( dat, 0, sizeof(struct SG_client_WRITE_data) );
     return 0;
 }
 
 // set write data manifest.
-// NOTE: shallow copy 
+// NOTE: shallow copy
 int SG_client_WRITE_data_set_write_delta( struct SG_client_WRITE_data* dat, struct SG_manifest* write_delta ) {
     dat->write_delta = write_delta;
     dat->has_write_delta = true;
@@ -1690,17 +1690,17 @@ int SG_client_WRITE_data_set_write_delta( struct SG_client_WRITE_data* dat, stru
 int SG_client_WRITE_data_set_size( struct SG_client_WRITE_data* dat, uint64_t size ) {
     dat->has_new_size = true;
     dat->new_size = size;
-    return 0; 
+    return 0;
 }
 
-// set write data mtime 
+// set write data mtime
 int SG_client_WRITE_data_set_mtime( struct SG_client_WRITE_data* dat, struct timespec* mtime ) {
     dat->mtime = *mtime;
     dat->has_mtime = true;
     return 0;
 }
 
-// set write data mode 
+// set write data mode
 int SG_client_WRITE_data_set_mode( struct SG_client_WRITE_data* dat, mode_t mode ) {
     dat->mode = mode;
     dat->has_mode = true;
@@ -1714,8 +1714,8 @@ int SG_client_WRITE_data_set_owner_id( struct SG_client_WRITE_data* dat, uint64_
     return 0;
 }
 
-// set refresh info 
-int SG_client_WRITE_data_set_refresh( struct SG_client_WRITE_data* dat, uint64_t read_freshness, uint64_t write_freshness ) {
+// set refresh info
+int SG_client_WRITE_data_set_refresh( struct SG_client_WRITE_data* dat, int32_t read_freshness, int32_t write_freshness ) {
    dat->has_consistency = true;
    dat->max_read_freshness = read_freshness;
    dat->max_write_freshness = write_freshness;
@@ -1724,7 +1724,7 @@ int SG_client_WRITE_data_set_refresh( struct SG_client_WRITE_data* dat, uint64_t
 
 // set routing info
 int SG_client_WRITE_data_set_routing_info( struct SG_client_WRITE_data* dat, uint64_t volume_id, uint64_t coordinator_id, uint64_t file_id, int64_t file_version ) {
-    
+
     dat->coordinator_id = coordinator_id;
     dat->file_id = file_id;
     dat->volume_id = volume_id;
@@ -1733,10 +1733,10 @@ int SG_client_WRITE_data_set_routing_info( struct SG_client_WRITE_data* dat, uin
     return 0;
 }
 
-// merge data into an md_entry from a WRITE data struct 
+// merge data into an md_entry from a WRITE data struct
 // return -EINVAL on conflicting information
 int SG_client_WRITE_data_merge( struct SG_client_WRITE_data* dat, struct md_entry* ent ) {
-    
+
     if( dat->has_write_delta && dat->has_new_size ) {
        // sanity check
        if( dat->new_size != SG_manifest_get_file_size( dat->write_delta ) ) {
@@ -1773,341 +1773,341 @@ int SG_client_WRITE_data_merge( struct SG_client_WRITE_data* dat, struct md_entr
 // the destination gateway is the coordinator ID in the manifest.
 // write-delta must be non-NULL
 // if new_owner and/or new_mode are non-NULL, they will be filled in as well
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 // return -EINVAL if we don't have any routing information set in dat, or if dat has conflicting size informaiton
 int SG_client_request_WRITE_setup( struct SG_gateway* gateway, SG_messages::Request* request, char const* fs_path, struct SG_client_WRITE_data* dat ) {
-   
+
    int rc = 0;
-   
+
    // sanity check...
    if( !dat->has_routing_information ) {
        SG_error("BUG: no routing information for '%s'\n", fs_path);
        return -EINVAL;
    }
-   
+
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
+
    struct SG_request_data reqdat;
    memset( &reqdat, 0, sizeof(reqdat) );
-   
+
    reqdat.coordinator_id = dat->coordinator_id;
    reqdat.fs_path = (char*)fs_path;
    reqdat.volume_id = dat->volume_id;
    reqdat.file_id = dat->file_id;
    reqdat.file_version = dat->file_version;
-   
+
    rc = SG_client_request_setup( gateway, request, &reqdat );
    if( rc != 0 ) {
-      
+
       SG_error("SG_client_request_setup('%s') rc = %d\n", fs_path, rc );
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::WRITE );
-   
+
    if( dat->has_write_delta ) {
-       
+
        // sending a manifest write delta
        rc = SG_manifest_serialize_blocks_to_request_protobuf( dat->write_delta, request );
        if( rc != 0 ) {
-      
+
            SG_error("SG_manifest_serialize_blocks_to_request_protobuf('%s') rc = %d\n", fs_path, rc );
            return rc;
        }
-   
+
        request->set_new_manifest_mtime_sec( dat->write_delta->mtime_sec );
        request->set_new_manifest_mtime_nsec( dat->write_delta->mtime_nsec );
 
        if( dat->has_new_size && dat->new_size != dat->write_delta->size ) {
-          
+
           SG_error("Conflicting sizes (%" PRIu64 " != %" PRIu64 ")\n", dat->new_size, dat->write_delta->size);
           return -EINVAL;
        }
 
        request->set_new_size( dat->write_delta->size );
    }
-   
+
    if( dat->has_owner_id ) {
       request->set_new_owner_id( dat->owner_id );
    }
-   
+
    if( dat->has_mode ) {
       request->set_new_mode( dat->mode );
    }
-   
+
    if( dat->has_mtime ) {
-      
+
       request->set_new_mtime_sec( dat->mtime.tv_sec );
       request->set_new_mtime_nsec( dat->mtime.tv_nsec );
    }
 
    if( dat->has_new_size ) {
-      
+
       request->set_new_size( dat->new_size );
    }
-   
+
    rc = md_sign< SG_messages::Request >( gateway_pkey, request );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
+
    return 0;
 }
 
 
 // make a signed TRUNCATE message, from an initialized reqdat.
 // the reqdat must be for a manifest
-// return 0 on success 
+// return 0 on success
 // return -EINVAL if the reqdat is not for a manifest
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int SG_client_request_TRUNCATE_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, off_t new_size ) {
-   
+
    int rc = 0;
-   
+
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
+
    if( !SG_request_is_manifest( reqdat ) ) {
       return -EINVAL;
    }
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::TRUNCATE );
    request->set_new_size( new_size );
-   
+
    request->set_new_manifest_mtime_sec( reqdat->manifest_timestamp.tv_sec );
    request->set_new_manifest_mtime_nsec( reqdat->manifest_timestamp.tv_nsec );
 
    request->set_coordinator_id( coordinator_id );
-   
+
    rc = md_sign< SG_messages::Request >( gateway_pkey, request );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
+
    return rc;
 }
 
 
 // make a signed RENAME request, from an initialized reqdat.
 // the reqdat must be for a manifest
-// return 0 on success 
+// return 0 on success
 // return -EINVAL if teh reqdat is not for a manifest
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int SG_client_request_RENAME_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, char const* new_path ) {
-   
+
    int rc = 0;
-   
+
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
+
    if( !SG_request_is_manifest( reqdat ) ) {
       return -EINVAL;
    }
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::RENAME );
    request->set_new_manifest_mtime_sec( reqdat->manifest_timestamp.tv_sec );
    request->set_new_manifest_mtime_nsec( reqdat->manifest_timestamp.tv_nsec );
    request->set_coordinator_id( coordinator_id );
-   
+
    try {
       request->set_new_fs_path( string(new_path) );
    }
    catch( bad_alloc& ba ) {
       return -ENOMEM;
    }
-   
+
    rc = md_sign< SG_messages::Request >( gateway_pkey, request );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
+
    return rc;
 }
 
 
 // make a signed DETACH request from an initialized reqdat
 // the reqdat must be for a manifest
-// return 0 on success 
+// return 0 on success
 // return -EINVAL if the reqdat is not for a manifest
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int SG_client_request_DETACH_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id ) {
-   
+
    int rc = 0;
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
+
    if( !SG_request_is_manifest( reqdat ) ) {
       return -EINVAL;
    }
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::DETACH );
    request->set_new_manifest_mtime_sec( reqdat->manifest_timestamp.tv_sec );
    request->set_new_manifest_mtime_nsec( reqdat->manifest_timestamp.tv_nsec );
    request->set_coordinator_id( coordinator_id );
-   
+
    rc = md_sign< SG_messages::Request >( gateway_pkey, request );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
+
    return rc;
 }
 
 
 // make a signed REFRESH request from an initialized reqdat
 // the reqdat must be for a manifest
-// return 0 on success 
+// return 0 on success
 // return -EINVAL if the reqdat is not for a manifest
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 int SG_client_request_REFRESH_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id ) {
-   
+
    int rc = 0;
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
+
    if( !SG_request_is_manifest( reqdat ) ) {
       return -EINVAL;
    }
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::REFRESH );
    request->set_new_manifest_mtime_sec( reqdat->manifest_timestamp.tv_sec );
    request->set_new_manifest_mtime_nsec( reqdat->manifest_timestamp.tv_nsec );
    request->set_coordinator_id( coordinator_id );
-   
+
    rc = md_sign< SG_messages::Request >( gateway_pkey, request );
    if( rc != 0 ) {
-      
+
       SG_error("md_sign rc = %d\n", rc );
       return rc;
    }
-   
+
    return rc;
 }
 
 
 // make a PUTCHUNKS request, optionally signing it
-// return 0 on sucess 
-// return -ENOMEM on OOM 
+// return 0 on sucess
+// return -ENOMEM on OOM
 int SG_client_request_PUTCHUNKS_setup_ex( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, struct SG_manifest_block* chunk_info, size_t num_chunk_info, bool sign ) {
-   
+
    int rc = 0;
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::PUTCHUNKS );
    request->set_coordinator_id( coordinator_id );
-  
+
    for( size_t i = 0; i < num_chunk_info; i++ ) {
 
-       // add block information 
+       // add block information
        SG_messages::ManifestBlock* mblock = NULL;
-   
+
        try {
-      
+
           mblock = request->add_blocks();
        }
        catch( bad_alloc& ba ) {
           return -ENOMEM;
        }
-   
+
        rc = SG_manifest_block_serialize_to_protobuf( &chunk_info[i], mblock );
        if( rc != 0 ) {
-      
+
           return rc;
        }
    }
-   
+
    if( sign ) {
        rc = md_sign< SG_messages::Request >( gateway_pkey, request );
        if( rc != 0 ) {
-      
+
           SG_error("md_sign rc = %d\n", rc );
           return rc;
        }
    }
-   
+
    return rc;
 }
 
-// make a signed PUTCHUNKS request 
+// make a signed PUTCHUNKS request
 int SG_client_request_PUTCHUNKS_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, struct SG_manifest_block* chunk_info, size_t num_chunk_info ) {
    return SG_client_request_PUTCHUNKS_setup_ex( gateway, request, reqdat, coordinator_id, chunk_info, num_chunk_info, true );
 }
 
 
 // make a DELETECHUNKS request, optionally signing it
-// return 0 on sucess 
-// return -ENOMEM on OOM 
+// return 0 on sucess
+// return -ENOMEM on OOM
 int SG_client_request_DELETECHUNKS_setup_ex( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, struct SG_manifest_block* chunk_info, size_t num_chunk_info, bool sign ) {
-   
+
    int rc = 0;
    EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
-   // basics 
+
+   // basics
    rc = SG_client_request_setup( gateway, request, reqdat );
    if( rc != 0 ) {
-      
+
       return rc;
    }
-   
+
    request->set_request_type( SG_messages::Request::DELETECHUNKS );
    request->set_coordinator_id( coordinator_id );
-   
+
    for( size_t i = 0; i < num_chunk_info; i++ ) {
 
-       // add block information 
+       // add block information
        SG_messages::ManifestBlock* mblock = NULL;
-   
+
        try {
-      
+
           mblock = request->add_blocks();
        }
        catch( bad_alloc& ba ) {
           return -ENOMEM;
        }
-   
+
        rc = SG_manifest_block_serialize_to_protobuf( &chunk_info[i], mblock );
        if( rc != 0 ) {
-      
+
           return rc;
        }
    }
@@ -2115,12 +2115,12 @@ int SG_client_request_DELETECHUNKS_setup_ex( struct SG_gateway* gateway, SG_mess
    if( sign ) {
        rc = md_sign< SG_messages::Request >( gateway_pkey, request );
        if( rc != 0 ) {
-      
+
           SG_error("md_sign rc = %d\n", rc );
           return rc;
        }
    }
-   
+
    return rc;
 }
 
@@ -2130,23 +2130,23 @@ int SG_client_request_DELETECHUNKS_setup( struct SG_gateway* gateway, SG_message
 }
 
 // make a signed SETXATTR request
-// return 0 on success 
-// return -ENOMEM on OOM 
+// return 0 on success
+// return -ENOMEM on OOM
 int SG_client_request_SETXATTR_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, char const* xattr_name, char const* xattr_value, size_t xattr_value_len, int flags ) {
-    
+
     int rc = 0;
     EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-   
-    // basics 
+
+    // basics
     rc = SG_client_request_setup( gateway, request, reqdat );
     if( rc != 0 ) {
-      
+
        return rc;
     }
-    
+
     request->set_request_type( SG_messages::Request::SETXATTR );
     request->set_coordinator_id( coordinator_id );
-    
+
     try {
         request->set_xattr_name( string(xattr_name) );
         request->set_xattr_value( string(xattr_value, xattr_value_len) );
@@ -2155,186 +2155,186 @@ int SG_client_request_SETXATTR_setup( struct SG_gateway* gateway, SG_messages::R
     catch( bad_alloc& ba ) {
         return -ENOMEM;
     }
-    
+
     rc = md_sign< SG_messages::Request >( gateway_pkey, request );
     if( rc != 0 ) {
-      
+
        SG_error("md_sign rc = %d\n", rc );
        return rc;
     }
-   
+
     return rc;
 }
 
 
-// make a signed REMOVEXATTR request 
-// return 0 on success 
-// return -ENOMEM on OOM 
+// make a signed REMOVEXATTR request
+// return 0 on success
+// return -ENOMEM on OOM
 int SG_client_request_REMOVEXATTR_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, char const* xattr_name ) {
-    
+
     int rc = 0;
     EVP_PKEY* gateway_pkey = SG_gateway_private_key( gateway );
-    
-    // basics 
+
+    // basics
     rc = SG_client_request_setup( gateway, request, reqdat );
     if( rc != 0 ) {
-        
+
         return rc;
     }
-    
+
     request->set_request_type( SG_messages::Request::REMOVEXATTR );
     request->set_coordinator_id( coordinator_id );
-    
+
     try {
         request->set_xattr_name( string(xattr_name) );
     }
     catch( bad_alloc& ba ) {
         return -ENOMEM;
     }
-    
+
     rc = md_sign< SG_messages::Request >( gateway_pkey, request );
     if( rc != 0 ) {
-      
+
        SG_error("md_sign rc = %d\n", rc );
        return rc;
     }
-   
+
     return rc;
 }
 
 
-// begin sending a request 
+// begin sending a request
 // serialize the given message, and set up a request cls.
 // NOTE: the download takes ownership of control_plane--the caller should not manipulate it in any way while the download is proceeding
 // NOTE: control_plane should be signed beforehand
 // return 0 on success, and set up *reqcls
-// return -ENOMEM on OOM 
+// return -ENOMEM on OOM
 // return -EAGAIN if the destination gateway is not known to us, but could become known if we reloaded our volumeconfiguration
 static int SG_client_request_begin( struct SG_gateway* gateway, uint64_t dest_gateway_id, SG_messages::Request* control_plane, struct SG_client_request_async* datareq, struct SG_client_request_cls* reqcls ) {
-   
+
    int rc = 0;
    char* gateway_url = NULL;
-   
+
    char* serialized_message = NULL;
    size_t serialized_message_len = 0;
-   
+
    struct curl_httppost* form_begin = NULL;
    struct curl_httppost* form_end = NULL;
-   
+
    struct ms_client* ms = SG_gateway_ms( gateway );
-   
-   // look up gateway 
+
+   // look up gateway
    rc = md_url_make_gateway_url( ms, dest_gateway_id, &gateway_url );
    if( rc != 0 ) {
-      
+
       if( rc != -ENOMEM ) {
-         
-         // we don't know about this gateway.  try refreshing 
+
+         // we don't know about this gateway.  try refreshing
          rc = -EAGAIN;
       }
       return rc;
    }
-   
+
    // serialize control plane
    rc = md_serialize< SG_messages::Request >( control_plane, &serialized_message, &serialized_message_len );
    if( rc != 0 ) {
-      
+
       SG_safe_free( gateway_url );
       return rc;
    }
-   
+
    // control-plane
    rc = curl_formadd( &form_begin, &form_end, CURLFORM_PTRNAME, SG_post_field_control,
-                                              CURLFORM_CONTENTSLENGTH, serialized_message_len, 
+                                              CURLFORM_CONTENTSLENGTH, serialized_message_len,
                                               CURLFORM_PTRCONTENTS, serialized_message,
                                               CURLFORM_CONTENTTYPE, "application/octet-stream",
                                               CURLFORM_END );
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("curl_formadd rc = %d\n", rc );
-      
+
       SG_safe_free( gateway_url );
       SG_safe_free( serialized_message );
-      
+
       return -ENOMEM;
    }
-   
+
    // do we have a data plane?
    if( datareq != NULL ) {
-      
+
       rc = curl_formadd( &form_begin, &form_end, CURLFORM_PTRNAME, SG_post_field_data,
                                                  CURLFORM_CONTENTSLENGTH, datareq->len,
                                                  CURLFORM_STREAM, datareq,
                                                  CURLFORM_CONTENTTYPE, "application/octet-stream",
                                                  CURLFORM_END );
-      
+
       if( rc != 0 ) {
-         
+
          SG_error("curl_formadd rc = %d\n", rc );
-         
+
          curl_formfree( form_begin );
          SG_safe_free( gateway_url );
          SG_safe_free( serialized_message );
-         
+
          return -ENOMEM;
       }
    }
-   
+
    // success!
    memset( reqcls, 0, sizeof(struct SG_client_request_cls) );
-   
+
    reqcls->url = gateway_url;
    reqcls->form_begin = form_begin;
    reqcls->serialized_message = serialized_message;
    reqcls->message = control_plane;
    reqcls->dest_gateway_id = dest_gateway_id;
-   
+
    return 0;
 }
 
 
-// finish processing a request 
+// finish processing a request
 // return 0 on success, and populate *reply
-// return -EBADMSG if the reply could not be validated 
+// return -EBADMSG if the reply could not be validated
 static int SG_client_request_end( struct SG_gateway* gateway, struct SG_chunk* serialized_reply, struct SG_client_request_cls* reqcls, SG_messages::Reply* reply ) {
-   
+
    int rc = 0;
    struct ms_client* ms = SG_gateway_ms( gateway );
    uint64_t volume_id = ms_client_get_volume_id( ms );
    SG_messages::Request* control_plane = reqcls->message;
-   
+
    // parse...
    rc = md_parse< SG_messages::Reply >( reply, serialized_reply->data, serialized_reply->len );
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("md_parse rc = %d\n", rc );
       return rc;
    }
-   
+
    // did it come from the request's destination?
    if( reply->gateway_id() != reqcls->dest_gateway_id ) {
-      
+
       SG_error("Gateway mismatch: expected %" PRIu64 ", got %" PRIu64 "\n", reqcls->dest_gateway_id, reply->gateway_id() );
       return -EBADMSG;
    }
-   
-   // verify message nonce 
+
+   // verify message nonce
    if( control_plane->message_nonce() != reply->message_nonce() ) {
-      
+
       SG_error("Message nonce mismatch: expected %" PRIX64 ", got %" PRIX64 "\n", control_plane->message_nonce(), reply->message_nonce() );
    }
-   
-   // verify signature 
+
+   // verify signature
    rc = ms_client_verify_gateway_message< SG_messages::Reply >( ms, volume_id, reqcls->dest_gateway_id, reply );
    if( rc != 0 ) {
-      
+
       SG_error("ms_client_verify_gateway_message( from=%" PRIu64 " ) rc = %d\n", reqcls->dest_gateway_id, rc );
       return -EBADMSG;
    }
-   
-   // done! 
+
+   // done!
    return 0;
 }
 
@@ -2343,15 +2343,15 @@ static int SG_client_request_end( struct SG_gateway* gateway, struct SG_chunk* s
 // that the remote gateway is down.  That is, the error is one of the following:
 // -EBADMSG, -EPROTO, -ETIMEDOUT
 bool SG_client_request_is_remote_unavailable( int error ) {
-   
+
    return (error == -EBADMSG || error == -ETIMEDOUT || error == -EPROTO);
 }
 
-// send a message as a (control plane, data plane) pair, synchronously, to another gateway 
-// return 0 on success 
-// return -ENOMEM if OOM 
+// send a message as a (control plane, data plane) pair, synchronously, to another gateway
+// return 0 on success
+// return -ENOMEM if OOM
 // return -EAGAIN if the request should be retried.  This could be because dest_gateway_id is not known to us, but could become known if we refreshed the volume config.
-// return -ETIMEDOUT on connection timeout 
+// return -ETIMEDOUT on connection timeout
 // return -EREMOTEIO if the HTTP status was >= 500 (indicates server-side I/O error)
 // return -EACCES if HTTP status was 401 or 403
 // return -EPERM on HTTP 400
@@ -2360,24 +2360,24 @@ bool SG_client_request_is_remote_unavailable( int error ) {
 // return -EPROTO if HTTP status was between 400 or 499, and not 401 or 403 (indicates a misconfiguration--they should never happen)
 // return -errno on socket- and recv-related errors
 int SG_client_request_send( struct SG_gateway* gateway, uint64_t dest_gateway_id, SG_messages::Request* control_plane, struct SG_chunk* data_plane, SG_messages::Reply* reply ) {
-   
+
    int rc = 0;
-   
+
    CURL* curl = NULL;
-   
+
    struct SG_client_request_cls reqcls;
    struct SG_chunk serialized_reply;
    struct SG_client_request_async* datareq = NULL;
-   
+
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
-   
+
    // TODO: connection pool
    curl = curl_easy_init();
    if( curl == NULL ) {
-      
+
       return -ENOMEM;
    }
-  
+
    // set up a synchronous in-RAM request stream
    datareq = SG_client_request_sync( data_plane );
    if( datareq == NULL ) {
@@ -2387,28 +2387,28 @@ int SG_client_request_send( struct SG_gateway* gateway, uint64_t dest_gateway_id
 
    rc = SG_client_request_begin( gateway, dest_gateway_id, control_plane, datareq, &reqcls );
    if( rc != 0 ) {
-      
+
       curl_easy_cleanup( curl );
       SG_client_request_sync_free( datareq );
       SG_error("SG_client_request_begin( %" PRIu64 " ) rc = %d\n", dest_gateway_id, rc );
       return rc;
    }
-   
-   // set up curl handle 
+
+   // set up curl handle
    md_init_curl_handle( conf, curl, reqcls.url, conf->connect_timeout );
-   
+
    curl_easy_setopt( curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL );    // force POST on redirect
    curl_easy_setopt( curl, CURLOPT_HTTPPOST, reqcls.form_begin );
    curl_easy_setopt( curl, CURLOPT_READFUNCTION, datareq->read_callback );
-   
-   // run the transfer 
+
+   // run the transfer
    rc = md_download_run( curl, SG_CLIENT_MAX_REPLY_LEN, &serialized_reply.data, &serialized_reply.len );
-   
+
    if( rc >= -499 && rc <= -400 ) {
-      
-      // 400-level HTTP error 
+
+      // 400-level HTTP error
       SG_error("md_download_run('%s') HTTP status %d\n", reqcls.url, -rc );
-      
+
       curl_easy_cleanup( curl );
       SG_client_request_sync_free( datareq );
       SG_client_request_cls_free( &reqcls );
@@ -2431,124 +2431,124 @@ int SG_client_request_send( struct SG_gateway* gateway, uint64_t dest_gateway_id
 
       return rc;
    }
-   
+
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("md_download_run('%s') rc = %d\n", reqcls.url, rc );
-      
+
       curl_easy_cleanup( curl );
       SG_client_request_sync_free( datareq );
       SG_client_request_cls_free( &reqcls );
-      
+
       return rc;
    }
-   
-   // get the reply 
+
+   // get the reply
    rc = SG_client_request_end( gateway, &serialized_reply, &reqcls, reply );
    if( rc != 0 ) {
-      
-      // failed 
+
+      // failed
       SG_error("SG_client_request_end('%s') rc = %d\n", reqcls.url, rc );
    }
-   
+
    curl_easy_cleanup( curl );
    SG_client_request_sync_free( datareq );
    SG_client_request_cls_free( &reqcls );
    SG_chunk_free( &serialized_reply );
-   
+
    return rc;
 }
 
 
-// send a message asynchronously to another gateway 
+// send a message asynchronously to another gateway
 // NOTE: the caller must NOT free *datareq until freeing the download context!
 // NOTE: the download context takes ownership of control_plane for the duration of the download!
 // return 0 on success, and set up *dlctx as an upload future
 // return -ENOMEM on OOM
 int SG_client_request_send_async( struct SG_gateway* gateway, uint64_t dest_gateway_id, SG_messages::Request* control_plane, struct SG_client_request_async* datareq, struct md_download_loop* dlloop, struct md_download_context* dlctx ) {
-   
+
    int rc = 0;
-   
+
    CURL* curl = NULL;
    struct md_downloader* dl = SG_gateway_dl( gateway );
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
-   
+
    struct SG_client_request_cls* reqcls = SG_CALLOC( struct SG_client_request_cls, 1 );
    if( reqcls == NULL ) {
-      
+
       return -ENOMEM;
    }
-   
+
    // TODO: connection pool
    curl = curl_easy_init();
    if( curl == NULL ) {
-      
+
       SG_safe_free( reqcls );
       return -ENOMEM;
    }
-   
+
    rc = SG_client_request_begin( gateway, dest_gateway_id, control_plane, datareq, reqcls );
    if( rc != 0 ) {
-      
+
       SG_error("SG_client_request_begin( %" PRIu64 " ) rc = %d\n", dest_gateway_id, rc );
-      
+
       curl_easy_cleanup( curl );
       SG_safe_free( reqcls );
       return rc;
    }
-   
-   // set up curl handle 
+
+   // set up curl handle
    md_init_curl_handle( conf, curl, reqcls->url, conf->connect_timeout );
-   
+
    curl_easy_setopt( curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL );    // force POST on redirect
    curl_easy_setopt( curl, CURLOPT_HTTPPOST, reqcls->form_begin );
 
    if( datareq != NULL ) {
        curl_easy_setopt( curl, CURLOPT_READFUNCTION, datareq->read_callback );
    }
-   
-   // set up the download handle 
+
+   // set up the download handle
    rc = md_download_context_init( dlctx, curl, SG_CLIENT_MAX_REPLY_LEN, reqcls );
    if( rc != 0 ) {
-      
+
       SG_error("md_download_context_init( %" PRIu64 " ) rc = %d\n", dest_gateway_id, rc );
-      
+
       SG_client_request_cls_free( reqcls );
       SG_safe_free( reqcls );
-      
+
       curl_easy_cleanup( curl );
       return rc;
    }
-   
-   // have the download loop watch this download 
+
+   // have the download loop watch this download
    rc = md_download_loop_watch( dlloop, dlctx );
    if( rc != 0 ) {
-      
+
       SG_error("md_download_loop_watch rc = %d\n", rc );
-      
+
       md_download_context_free( dlctx, NULL );
-      
+
       curl_easy_cleanup( curl );
       SG_client_request_cls_free( reqcls );
       SG_safe_free( reqcls );
    }
-   
-   // start the download 
+
+   // start the download
    rc = md_download_context_start( dl, dlctx );
    if( rc != 0 ) {
-      
+
       SG_error("md_download_context_start( %" PRIu64 " ) rc = %d\n", dest_gateway_id, rc );
-      
+
       md_download_context_free( dlctx, NULL );
-      
+
       curl_easy_cleanup( curl );
       SG_client_request_cls_free( reqcls );
       SG_safe_free( reqcls );
-      
+
       return rc;
    }
-   
+
    return 0;
 }
 
@@ -2556,83 +2556,82 @@ int SG_client_request_send_async( struct SG_gateway* gateway, uint64_t dest_gate
 // finish sending a message to another gateway
 // return 0 on success, and set up *reply with the validated reply
 // return -EINVAL if the download context was not used in a previous call to SG_client_request_send_async
-// return -EBADMSG if the reply was invalid 
+// return -EBADMSG if the reply was invalid
 // return -ENODATA if the download did not succeed with HTTP 200
 // return -ETIMEDOUT if the transfer did not complete in time
 // NOTE: this frees up dlctx
 int SG_client_request_send_finish( struct SG_gateway* gateway, struct md_download_context* dlctx, SG_messages::Reply* reply ) {
-   
+
    int rc = 0;
    int http_status = 0;
-   
+
    struct md_syndicate_conf* conf = SG_gateway_conf( gateway );
    struct SG_chunk serialized_reply;
    struct SG_client_request_cls* reqcls = NULL;
-   
-   // get request cls 
+
+   // get request cls
    reqcls = (struct SG_client_request_cls*)md_download_context_get_cls( dlctx );
    if( reqcls == NULL ) {
-      
+
       // not a download
       SG_error("FATAL BUG: not a client download: %p\n", dlctx );
       exit(1);
    }
 
    md_download_context_set_cls( dlctx, NULL );
-   
-   // wait for this download to finish 
+
+   // wait for this download to finish
    rc = md_download_context_wait( dlctx, conf->transfer_timeout * 1000 );
    if( rc != 0 ) {
-   
+
       SG_error("md_download_context_wait( %p ) rc = %d\n", dlctx, rc );
-      
+
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return rc;
    }
-   
+
    // succeeded?
    if( !md_download_context_succeeded( dlctx, 200 ) ) {
-      
+
       // nope
       http_status = md_download_context_get_http_status( dlctx );
-      
+
       SG_error("download %p finished with HTTP status %d\n", dlctx, http_status );
-      
+
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return -ENODATA;
    }
-   
-   // get data 
+
+   // get data
    rc = md_download_context_get_buffer( dlctx, &serialized_reply.data, &serialized_reply.len );
    if( rc != 0 ) {
-      
+
       SG_error("md_download_context_get_buffer( %p ) rc = %d\n", dlctx, rc );
-      
+
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return rc;
    }
-   
-   // parse and validate 
+
+   // parse and validate
    rc = SG_client_request_end( gateway, &serialized_reply, reqcls, reply );
-   
+
    SG_chunk_free( &serialized_reply );
-   
+
    if( rc != 0 ) {
-      
+
       SG_error("SG_client_request_end( %p ) rc = %d\n", dlctx, rc );
-      
+
       SG_client_download_async_cleanup( dlctx );
       SG_client_request_cls_cleanup_and_free( reqcls );
       return rc;
    }
-   
-   // clean up 
+
+   // clean up
    SG_client_download_async_cleanup( dlctx );
    SG_client_request_cls_cleanup_and_free( reqcls );
-   
+
    return rc;
 }
-

--- a/libsyndicate/client.h
+++ b/libsyndicate/client.h
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Syndicate Gateway client API 
+// Syndicate Gateway client API
 
 #ifndef _LIBSYNDICATE_CLIENT_H_
 #define _LIBSYNDICATE_CLIENT_H_
@@ -27,16 +27,16 @@
 // maximum length of a gateway reply: 1MB
 #define SG_CLIENT_MAX_REPLY_LEN         1024000
 
-// asynchronous upload 
+// asynchronous upload
 struct SG_client_request_async;
 typedef size_t (*SG_client_read_callback_t)( char*, size_t, size_t, void* );
 
 extern "C" {
-    
+
 // extra data to include in a write
 struct SG_client_WRITE_data;
 
-// set up a write reqeust 
+// set up a write reqeust
 struct SG_client_WRITE_data* SG_client_WRITE_data_new(void);
 int SG_client_WRITE_data_init( struct SG_client_WRITE_data* dat );
 int SG_client_WRITE_data_set_write_delta( struct SG_client_WRITE_data* dat, struct SG_manifest* write_delta );
@@ -44,7 +44,7 @@ int SG_client_WRITE_data_set_mtime( struct SG_client_WRITE_data* dat, struct tim
 int SG_client_WRITE_data_set_mode( struct SG_client_WRITE_data* dat, mode_t mode );
 int SG_client_WRITE_data_set_size( struct SG_client_WRITE_data* dat, uint64_t mode );
 int SG_client_WRITE_data_set_owner_id( struct SG_client_WRITE_data* dat, uint64_t owner_id );
-int SG_client_WRITE_data_set_refresh( struct SG_client_WRITE_data* dat, uint64_t read_freshness, uint64_t write_freshness );
+int SG_client_WRITE_data_set_refresh( struct SG_client_WRITE_data* dat, int32_t read_freshness, int32_t write_freshness );
 int SG_client_WRITE_data_set_routing_info( struct SG_client_WRITE_data* dat, uint64_t volume_id, uint64_t coordinator_id, uint64_t file_id, int64_t file_version );
 int SG_client_WRITE_data_merge( struct SG_client_WRITE_data* dat, struct md_entry* ent );
 
@@ -73,7 +73,7 @@ int SG_client_request_DELETECHUNKS_setup_ex( struct SG_gateway* gateway, SG_mess
 int SG_client_request_SETXATTR_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, char const* xattr_name, char const* xattr_value, size_t xattr_value_len, int flags );
 int SG_client_request_REMOVEXATTR_setup( struct SG_gateway* gateway, SG_messages::Request* request, struct SG_request_data* reqdat, uint64_t coordinator_id, char const* xattr_name );
 
-// gateway-to-gateway messaging.  The corresponding driver methods will be run 
+// gateway-to-gateway messaging.  The corresponding driver methods will be run
 struct SG_client_request_async* SG_client_request_async_new(void);
 void SG_client_request_async_init( struct SG_client_request_async* req, SG_client_read_callback_t read_callback, size_t maxlen, void* cls );
 void* SG_client_request_async_cls( struct SG_client_request_async* datareq );
@@ -81,13 +81,13 @@ int SG_client_request_send( struct SG_gateway* gateway, uint64_t dest_gateway_id
 int SG_client_request_send_async( struct SG_gateway* gateway, uint64_t dest_gateway_id, SG_messages::Request* control_plane, struct SG_client_request_async* datareq, struct md_download_loop* dlloop, struct md_download_context* dlctx );
 int SG_client_request_send_finish( struct SG_gateway* gateway, struct md_download_context* dlctx, SG_messages::Reply* reply );
 
-// low-level download logic 
+// low-level download logic
 int SG_client_download_async_start( struct SG_gateway* gateway, struct md_download_loop* dlloop, struct md_download_context* dlctx, uint64_t chunk_id, char* url, off_t max_size, void* cls, void (*free_cls)(void*) );
 int SG_client_download_async_wait( struct md_download_context* dlctx, char** chunk_buf, off_t* chunk_len, void** cls );
 void SG_client_download_async_cleanup( struct md_download_context* dlctx );
 void SG_client_download_async_cleanup_loop( struct md_download_loop* dlloop );
 
-// signed block authentication 
+// signed block authentication
 int SG_client_block_sign( struct SG_gateway* gateway, struct SG_request_data* reqdat, struct SG_chunk* block_data, struct SG_chunk* signed_block_data );
 int SG_client_block_verify( struct SG_gateway* gateway, struct SG_chunk* signed_block, uint64_t* ret_data_offset );
 
@@ -96,4 +96,4 @@ bool SG_client_request_is_remote_unavailable( int error );
 
 }
 
-#endif 
+#endif

--- a/libsyndicate/libsyndicate.h
+++ b/libsyndicate/libsyndicate.h
@@ -77,14 +77,14 @@ using namespace std;
 struct md_entry {
    int type;            // file or directory?
    char* name;          // name of this entry
-   uint64_t file_id;    // id of this file 
+   uint64_t file_id;    // id of this file
    int64_t ctime_sec;   // creation time (seconds)
    int32_t ctime_nsec;  // creation time (nanoseconds)
    int64_t mtime_sec;   // last-modified time (seconds)
    int32_t mtime_nsec;  // last-modified time (nanoseconds)
    int64_t manifest_mtime_sec;  // manifest last-mod time (actual last-write time, regardless of utime) (seconds)
    int32_t manifest_mtime_nsec; // manifest last-mod time (actual last-write time, regardless of utime) (nanoseconds)
-   int64_t write_nonce; // last-write nonce 
+   int64_t write_nonce; // last-write nonce
    int64_t xattr_nonce; // xattr write nonce
    int64_t version;     // file version
    int32_t max_read_freshness;      // how long is this entry fresh until it needs revalidation?
@@ -98,14 +98,14 @@ struct md_entry {
    int64_t generation;  // n, as in, the nth item to ever be created in the parent directory
    int64_t num_children; // number of children this entry has (if it's a directory)
    int64_t capacity;    // maximum index number a child can have (i.e. used by listdir())
-   
+
    unsigned char* ent_sig;      // signature over this entry from the coordinator, as well as any ancillary data below
    size_t ent_sig_len;
-   
+
    // ancillary data: not always filled in
-   
+
    uint64_t parent_id;  // id of this file's parent directory
-   
+
    // putxattr, removexattr only (and only from the coordinator)
    unsigned char* xattr_hash;   // hash over (volume ID, file ID, xattr_nonce, sorted(xattr name, xattr value))
 };
@@ -130,12 +130,12 @@ struct md_entry {
 
 // server configuration
 struct md_syndicate_conf {
-   
-   // paths 
+
+   // paths
    char* config_file_path;                            // *absolute* path to the config file.
    char* volumes_path;                                // path to the directory containing volume keys and certs
-   char* gateways_path;                               // path to the directory containing gateway keys and certs 
-   char* users_path;                                  // path to the directory containing user keys and certs 
+   char* gateways_path;                               // path to the directory containing gateway keys and certs
+   char* users_path;                                  // path to the directory containing user keys and certs
    char* drivers_path;                                // path to the directory containing drivers
    char* syndicate_path;                              // path to the directory containing Syndicate public keys
    char* logs_path;                                   // path to the logfile directory to store gateway logs
@@ -143,34 +143,34 @@ struct md_syndicate_conf {
    char* certs_root;                                  // path to the *root* directory containing cached certs from other users, volumes, and gateways.
    char* certs_path;                                  // path to the *gateway-specific* directory containing cached certs.  Derived from certs_root; set at runtime.
    char* ipc_root;                                    // path to any temporary driver state (IPC objects like UNIX domain sockets or named pipes)
-   
-   // command-line options 
+
+   // command-line options
    char* volume_name;                                 // name of the volume we're connected to
    char* gateway_name;                                // name of this gateway
    char* ms_username;                                 // MS username for this user
-   
+
    // gateway fields
-   int64_t default_read_freshness;                    // default number of milliseconds a file can age before needing refresh for reads
-   int64_t default_write_freshness;                   // default number of milliseconds a file can age before needing refresh for writes
+   int32_t default_read_freshness;                    // default number of milliseconds a file can age before needing refresh for reads
+   int32_t default_write_freshness;                   // default number of milliseconds a file can age before needing refresh for writes
    bool gather_stats;                                 // gather statistics or not?
-   int max_read_retry;                                // maximum number of times to retry a read (i.e. fetching a block or manifest) before considering it failed 
+   int max_read_retry;                                // maximum number of times to retry a read (i.e. fetching a block or manifest) before considering it failed
    int max_write_retry;                               // maximum number of times to retry a write (i.e. replicating a block or manifest) before considering it failed
-   int max_metadata_read_retry;                       // maximum number of times to retry a metadata read before considering it failed 
+   int max_metadata_read_retry;                       // maximum number of times to retry a metadata read before considering it failed
    int max_metadata_write_retry;                      // maximum number of times to retry a metadata write before considering it failed
    int connect_timeout;                               // number of seconds to wait to connect for data
    int transfer_timeout;                              // how long a manifest/block transfer is allowed to take (in seconds)
    bool verify_peer;                                  // whether or not to verify the gateway server's SSL certificate with peers (if using HTTPS to talk to them)
-   uint64_t cache_size_limit;                         // soft limit on the size in bytes of the cache 
+   uint64_t cache_size_limit;                         // soft limit on the size in bytes of the cache
    char* metadata_url;                                // MS url
    uint64_t config_reload_freq;                       // how often do we check for a new configuration from the MS?
-   
-   // cert and key processors 
+
+   // cert and key processors
    char* certs_reload_helper;                         // command to go reload and revalidate all certificates
    char* driver_reload_helper;                        // command to go reload and revalidate the driver
-   char** helper_env;                                 // environment variables to pass 
+   char** helper_env;                                 // environment variables to pass
    size_t num_helper_envs;
    size_t max_helper_envs;
-   
+
    // debug
    int debug_lock;                                    // print verbose information on locks
 
@@ -186,7 +186,7 @@ struct md_syndicate_conf {
    uint64_t owner;                                    // what is our user ID in Syndicate?  Files created in this UG will assume this UID as their owner
    uint64_t gateway;                                  // what is our gateway ID?
    uint64_t volume;                                   // what is our volume ID?
-   uint64_t gateway_type;                             // type of gateway 
+   uint64_t gateway_type;                             // type of gateway
    int64_t cert_bundle_version;                       // the version of the cert bundle (obtained during initialization and kept in sync through config reloads)
    int64_t gateway_version;                           // the version of this gateway's cert (obtained during initialization and kept in sync through config reloads)
    int64_t volume_version;                            // the version of the volume (obtained during initialization and kept in sync through config reloads)
@@ -196,14 +196,14 @@ struct md_syndicate_conf {
    char* driver_exec_path;                            // what is the path to the driver to execute?
    char** driver_roles;                               // what are the different role(s) this gateway's driver takes on?
    size_t num_driver_roles;
-   
+
    char* user_pubkey_pem;                             // Syndicate User public key (PEM format) (if the private key is given, this will be generated from it)
    size_t user_pubkey_pem_len;
    EVP_PKEY* user_pubkey;
    char* volume_pubkey_pem;                           // volume metadata public key (PEM format).  Corresponds to the volume owner's public key
    size_t volume_pubkey_pem_len;
    EVP_PKEY* volume_pubkey;
-   
+
    // misc
    bool is_client;                                    // if true for a UG, always fetch data from RGs
 };
@@ -212,7 +212,7 @@ struct md_syndicate_conf {
 #define SG_GATEWAY_ANON            (uint64_t)0xFFFFFFFFFFFFFFFFLL
 #define SG_GATEWAY_TOOL            (uint64_t)0xFFFFFFFFFFFFFFFELL       // gateway id used by messages from the administrative tool
 
-// config elements 
+// config elements
 #define SG_CONFIG_VOLUMES_PATH            "volumes"
 #define SG_CONFIG_GATEWAYS_PATH           "gateways"
 #define SG_CONFIG_USERS_PATH              "users"
@@ -287,7 +287,7 @@ typedef map<uint64_t, struct ms_gateway_cert*> ms_cert_bundle;
 
 extern "C" {
 
-// library config 
+// library config
 int md_debug( struct md_syndicate_conf* conf, int level );
 int md_error( struct md_syndicate_conf* conf, int level );
 int md_signals( int use_signals );
@@ -346,7 +346,7 @@ int md_parse_header( char* header_buf, char const* header_name, char** header_va
 uint64_t md_parse_header_uint64( char* hdr, off_t offset, size_t size );
 uint64_t* md_parse_header_uint64v( char* hdr, off_t offset, size_t size, size_t* ret_len );
 
-// networking 
+// networking
 char* md_get_hostname( struct md_syndicate_conf* conf );
 int md_set_hostname( struct md_syndicate_conf* conf, char const* hostname );
 
@@ -358,12 +358,12 @@ int md_init_client( struct md_syndicate_conf* conf, struct ms_client* client, st
 
 int md_shutdown(void);
 
-// load certs 
+// load certs
 int md_certs_reload( struct md_syndicate_conf* conf, EVP_PKEY** syndicate_pubkey, ms::ms_user_cert* user_cert, ms::ms_user_cert* volume_owner_cert, ms::ms_volume_metadata* volume_cert, ms_cert_bundle* gateway_certs );
 int md_driver_reload( struct md_syndicate_conf* conf, struct ms_gateway_cert* cert );
 struct ms_gateway_cert* md_gateway_cert_find( ms_cert_bundle* gateway_certs, uint64_t gateway_id );
 
-// driver 
+// driver
 int md_conf_set_driver_params( struct md_syndicate_conf* conf, char const* driver_exec_path, char const** driver_roles, size_t num_roles );
 
 }
@@ -380,17 +380,17 @@ template <class T> int md_serialize( T* protobuf, char** bits, size_t* bits_len 
       SG_error("SerializeToString exception: %s\n", e.what() );
       return -EINVAL;
    }
-   
+
    char* ret = SG_CALLOC( char, msgbits.size() );
    if( ret == NULL ) {
       return -ENOMEM;
    }
-   
+
    memcpy( ret, msgbits.data(), msgbits.size() );
-   
+
    *bits = ret;
    *bits_len = msgbits.size();
-   
+
    return 0;
 }
 
@@ -406,12 +406,12 @@ template <class T> int md_parse( T* protobuf, char const* bits, size_t bits_len 
       SG_error("ParseFromString exception: %s\n", e.what() );
       return -EINVAL;
    }
-   
+
    if( !valid ) {
       SG_error("ParseFromString rc = %d (missing %s)\n", valid, protobuf->InitializationErrorString().c_str() );
       return -EINVAL;
    }
-   
+
    return 0;
 }
 


### PR DESCRIPTION
Change a type of `read-freshness` and `write-freshness` to `int32_t` in order to match to a structure `md_entry`.
- Jude would you double check this commit before merge?