### PR TITLE
Allow gateway update when an user owns a gateway

### DIFF
--- a/ms/storage/storage.py
+++ b/ms/storage/storage.py
@@ -953,7 +953,7 @@ def update_gateway( g_name_or_id, **kw ):
        raise Exception("No such gateway '%s'" % g_name_or_id)
 
    # user must own this gateway, or gateway must be anonymous and the user must be the volume owner, or the caller user must be admin
-   if (gateway.owner_id != USER_ID_ANON and gateway.owner_id != user.owner_id) or (gateway.owner_id == USER_ID_ANON and user.owner_id != volume.owner_id) or (not caller_user.is_admin):
+   if ((gateway.owner_id != USER_ID_ANON and gateway.owner_id != user.owner_id) or (gateway.owner_id == USER_ID_ANON and user.owner_id != volume.owner_id)) and (not caller_user.is_admin):
        owning_user_id = user.owner_id if gateway.owner_id != USER_ID_ANON else volume.owner_id
        raise Exception("User '%s' does not own gateway '%s' (%s)" % (owning_user_id, gateway.name, gateway.owner_id))
 


### PR DESCRIPTION
This fixes a failure at gateway update even when an user owns the gateway. 

Previously, I met following error message.

```
ag_pov_1  | [2016-12-15 07:52:11,581] [ERROR] [syndicate:1106] (93) Internal err
or Code: -32603, Data: User '4506416817130434844' does not own gateway 'ag_pov' 
(4506416817130434844)
ag_pov_1  | Traceback (most recent call last):
ag_pov_1  |   File "/usr/bin/syndicate", line 1103, in main
ag_pov_1  |     result = client.ms_rpc( rpc_client, method_name, *args, **kw )
ag_pov_1  |   File "/usr/lib/python2.7/dist-packages/syndicate/util/client.py", 
line 272, in ms_rpc
ag_pov_1  |     ret = method_callable( *args, **kw )
ag_pov_1  |   File "/usr/lib/python2.7/dist-packages/syndicate/ms/jsonrpc.py", l
ine 434, in default
ag_pov_1  |     return self.request()
ag_pov_1  |   File "/usr/lib/python2.7/dist-packages/syndicate/ms/jsonrpc.py", l
ine 533, in request
ag_pov_1  |     raise Exception('%s Code: %s, Data: %s' % (result['error']['mess
age'], result['error']['code'], data))
ag_pov_1  | Exception: Internal error Code: -32603, Data: User '4506416817130434
844' does not own gateway 'ag_pov' (4506416817130434844)
ag_pov_1  | Help for 'update_gateway':
```